### PR TITLE
Codegen type parameters for serde_json::Value fields

### DIFF
--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [fb8f88d824489a878aee1e0badde7d8e129f8767](https://github.com/aws/aws-lambda-go/commit/fb8f88d824489a878aee1e0badde7d8e129f8767).
+Generated from commit [9e3676ee8ca83aee500682f382e10b9d03660093](https://github.com/aws/aws-lambda-go/commit/9e3676ee8ca83aee500682f382e10b9d03660093).

--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [9e3676ee8ca83aee500682f382e10b9d03660093](https://github.com/aws/aws-lambda-go/commit/9e3676ee8ca83aee500682f382e10b9d03660093).
+Generated from commit [fb8f88d824489a878aee1e0badde7d8e129f8767](https://github.com/aws/aws-lambda-go/commit/fb8f88d824489a878aee1e0badde7d8e129f8767).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -24,8 +24,16 @@ pub struct ApiGatewayProxyRequest {
     pub headers: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
+    #[serde(rename = "multiValueHeaders")]
+    pub multi_value_headers: HashMap<String, Vec<String>>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
     #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "multiValueQueryStringParameters")]
+    pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(rename = "pathParameters")]
@@ -122,6 +130,10 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "accessKey")]
+    pub access_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sourceIp")]
@@ -253,8 +265,16 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     pub headers: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
+    #[serde(rename = "multiValueHeaders")]
+    pub multi_value_headers: HashMap<String, Vec<String>>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
     #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "multiValueQueryStringParameters")]
+    pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(rename = "pathParameters")]

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -1,5 +1,7 @@
 use custom_serde::*;
 use std::collections::HashMap;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `ApiGatewayProxyRequest` contains data coming from the API Gateway proxy
@@ -22,16 +24,8 @@ pub struct ApiGatewayProxyRequest {
     pub headers: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueHeaders")]
-    pub multi_value_headers: HashMap<String, Vec<String>>,
-    #[serde(deserialize_with = "deserialize_lambda_map")]
-    #[serde(default)]
     #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
-    #[serde(deserialize_with = "deserialize_lambda_map")]
-    #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
-    pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(rename = "pathParameters")]
@@ -67,7 +61,10 @@ pub struct ApiGatewayProxyResponse {
 /// `ApiGatewayProxyRequestContext` contains the information to identify the AWS account and resources invoking the
 /// Lambda function. It also includes Cognito identity information for the caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ApiGatewayProxyRequestContext {
+pub struct ApiGatewayProxyRequestContext<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accountId")]
@@ -90,7 +87,8 @@ pub struct ApiGatewayProxyRequestContext {
     pub resource_path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub authorizer: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub authorizer: HashMap<String, T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]
@@ -124,10 +122,6 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
-    #[serde(deserialize_with = "deserialize_lambda_string")]
-    #[serde(default)]
-    #[serde(rename = "accessKey")]
-    pub access_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "sourceIp")]
@@ -259,16 +253,8 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     pub headers: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueHeaders")]
-    pub multi_value_headers: HashMap<String, Vec<String>>,
-    #[serde(deserialize_with = "deserialize_lambda_map")]
-    #[serde(default)]
     #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
-    #[serde(deserialize_with = "deserialize_lambda_map")]
-    #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
-    pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(rename = "pathParameters")]
@@ -283,7 +269,10 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
 
 /// `ApiGatewayCustomAuthorizerResponse` represents the expected format of an API Gateway authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ApiGatewayCustomAuthorizerResponse {
+pub struct ApiGatewayCustomAuthorizerResponse<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "principalId")]
@@ -292,7 +281,8 @@ pub struct ApiGatewayCustomAuthorizerResponse {
     pub policy_document: ApiGatewayCustomAuthorizerPolicy,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub context: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub context: HashMap<String, T1>,
     #[serde(rename = "usageIdentifierKey")]
     pub usage_identifier_key: Option<String>,
 }

--- a/aws_lambda_events/src/generated/appsync.rs
+++ b/aws_lambda_events/src/generated/appsync.rs
@@ -1,14 +1,20 @@
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `AppSyncResolverTemplate` represents the requests from AppSync to Lambda
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct AppSyncResolverTemplate {
+pub struct AppSyncResolverTemplate<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
     pub operation: AppSyncOperation,
-    pub payload: Value,
+    #[serde(bound="")]
+    pub payload: T1,
 }
 
 pub type AppSyncOperation = String;

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -1,11 +1,16 @@
 use chrono::{DateTime, Utc};
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
 /// `AutoScalingEvent` struct is used to parse the json for auto scaling event types //
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct AutoScalingEvent {
+pub struct AutoScalingEvent<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     /// The version of event data
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -38,5 +43,6 @@ pub struct AutoScalingEvent {
     pub resources: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub detail: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub detail: HashMap<String, T1>,
 }

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -1,11 +1,16 @@
 use chrono::{DateTime, Utc};
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 
 /// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
 /// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct CloudWatchEvent {
+pub struct CloudWatchEvent<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
@@ -28,5 +33,6 @@ pub struct CloudWatchEvent {
     #[serde(default)]
     pub region: Option<String>,
     pub resources: Vec<String>,
-    pub detail: Value,
+    #[serde(bound="")]
+    pub detail: T1,
 }

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -1,5 +1,7 @@
 use custom_serde::*;
 use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -28,7 +30,10 @@ pub struct SnsEventRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct SnsEntity {
+pub struct SnsEntity<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "Signature")]
@@ -47,8 +52,9 @@ pub struct SnsEntity {
     pub topic_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
+    #[serde(bound="")]
     #[serde(rename = "MessageAttributes")]
-    pub message_attributes: HashMap<String, Value>,
+    pub message_attributes: HashMap<String, T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "SignatureVersion")]

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -726,9 +726,9 @@ fn translate_go_type_to_rust_type(go_type: GoType, generic_counter: Option<&mut 
             libraries.insert("std::collections::HashMap".to_string());
 
             RustType {
-                annotations: annotations,
                 value: format!("HashMap<{}, {}>", key_data.value, value_data.value),
-                generics: generics,
+                annotations,
+                generics,
                 libraries,
             }
         }

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -196,7 +196,7 @@ fn parse_local_type_alias(pairs: Pairs<Rule>) -> Result<Option<(String, RustType
     let name = name.expect("parsed name");
     let target = target.expect("parsed target");
 
-    Ok(Some((name, translate_go_type_to_rust_type(target)?)))
+    Ok(Some((name, translate_go_type_to_rust_type(target, None)?)))
 }
 
 fn parse_package_type_alias(pairs: Pairs<Rule>) -> Result<Option<(String, RustType)>, Error> {
@@ -219,7 +219,7 @@ fn parse_package_type_alias(pairs: Pairs<Rule>) -> Result<Option<(String, RustTy
     let name = name.expect("parsed name");
     let target = target.expect("parsed target");
 
-    Ok(Some((name, translate_go_type_to_rust_type(target)?)))
+    Ok(Some((name, translate_go_type_to_rust_type(target, None)?)))
 }
 
 fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>), Error> {
@@ -272,16 +272,34 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
 
     let mut libraries: HashSet<String> = HashSet::new();
 
+    let mut generics = 0;
+
     for f in fields {
         // Translate the name.
         let member_name = mangle(&f.name.to_snake_case());
 
+        let mut rust_data = translate_go_type_to_rust_type(f.go_type, Some(&mut generics))?;
+        let mut rust_type = rust_data.value;
+
+        for generic in rust_data.generics {
+            match generic.default {
+                None => {
+                    rust_struct.generic(&generic.value);
+                }
+                Some(default) => {
+                    rust_struct.generic(format!("{}={}", generic.value, default).as_str());
+                }
+            }
+
+            for bound in generic.bounds {
+                rust_struct.bound(&generic.value, bound);
+            }
+        }
+
         // Extract the code and the libraries from the result.
-        let mut rust_data = translate_go_type_to_rust_type(f.go_type)?;
         for lib in rust_data.libraries.iter() {
             libraries.insert(lib.clone());
         }
-        let mut rust_type = rust_data.value;
 
         // Make fields optional if they are optional in the json.
         if f.omit_empty {
@@ -495,6 +513,14 @@ struct RustType {
     annotations: Vec<String>,
     libraries: HashSet<String>,
     value: String,
+    generics: Vec<RustGeneric>,
+}
+
+#[derive(Clone)]
+struct RustGeneric {
+    value: String,
+    default: Option<String>,
+    bounds: Vec<String>,
 }
 
 fn parse_go_type(pairs: Pairs<Rule>) -> Result<GoType, Error> {
@@ -625,11 +651,12 @@ fn make_rust_type_with_no_libraries(value: &str) -> RustType {
     RustType {
         annotations: vec![],
         value: value.to_string(),
+        generics: vec![],
         libraries: HashSet::new(),
     }
 }
 
-fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
+fn translate_go_type_to_rust_type(go_type: GoType, generic_counter: Option<&mut usize>) -> Result<RustType, Error> {
     let rust_type = match &go_type {
         GoType::StringType => make_rust_type_with_no_libraries("String"),
         GoType::BoolType => make_rust_type_with_no_libraries("bool"),
@@ -639,67 +666,108 @@ fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
         GoType::FloatType => make_rust_type_with_no_libraries("f64"),
         GoType::UserDefined(x) => make_rust_type_with_no_libraries(&x.to_camel_case()),
         GoType::ArrayType(x) => {
-            let mut i = translate_go_type_to_rust_type(*x.clone())?;
-            let mut libraries = HashSet::new();
-            libraries.insert("super::super::encodings::Base64Data".to_string());
+            let mut i = translate_go_type_to_rust_type(*x.clone(), generic_counter)?;
+            
             if i.value == "u8" {
+                let mut libraries = i.libraries.clone();
+                libraries.insert("super::super::encodings::Base64Data".to_string());
                 // Handle []u8 special, as it is base64 encoded.
                 RustType {
-                    annotations: vec![],
+                    annotations: i.annotations,
                     value: "Base64Data".to_string(),
+                    generics: i.generics,
                     libraries: libraries,
                 }
             } else {
                 RustType {
-                    annotations: vec![],
+                    annotations: i.annotations,
                     value: format!("Vec<{}>", i.value),
+                    generics: i.generics,
                     libraries: i.libraries,
                 }
             }
         },
         GoType::PointerType(v) => {
-            let data = translate_go_type_to_rust_type(*v.clone())?;
+            let data = translate_go_type_to_rust_type(*v.clone(), generic_counter)?;
             let libraries: HashSet<String> = data.libraries.iter().cloned().collect();
             RustType {
-                annotations: vec![],
+                annotations: data.annotations,
                 value: format!("Option<{}>", data.value),
+                generics: data.generics,
                 libraries,
             }
         },
         GoType::MapType(k, v) => {
-            let key_data = translate_go_type_to_rust_type(*k.clone())?;
-            let value_data = translate_go_type_to_rust_type(*v.clone())?;
+            // TODO can we use a ref to the option to save this dance?
+            let mut generics = 0;
 
-            let key_libs: HashSet<String> = key_data.libraries.iter().cloned().collect();
-            let value_libs: HashSet<String> = value_data.libraries.iter().cloned().collect();
+            if let Some(ref generic_counter) = generic_counter {
+                generics = **generic_counter;
+            }
 
-            let mut libraries: HashSet<String> = key_libs.union(&value_libs).cloned().collect();
+            let key_data = translate_go_type_to_rust_type(*k.clone(), Some(&mut generics))?;
+            let value_data = translate_go_type_to_rust_type(*v.clone(), Some(&mut generics))?;
+
+            if let Some(mut generic_counter) = generic_counter {
+                *generic_counter = generics;
+            }
+
+            let mut annotations = Vec::new();
+            annotations.extend(key_data.annotations);
+            annotations.extend(value_data.annotations);
+
+            let mut generics = Vec::new();
+            generics.extend(key_data.generics);
+            generics.extend(value_data.generics);
+
+            let mut libraries = HashSet::new();
+            libraries.extend(key_data.libraries);
+            libraries.extend(value_data.libraries);
             libraries.insert("std::collections::HashMap".to_string());
 
             RustType {
-                annotations: vec![],
+                annotations: annotations,
                 value: format!("HashMap<{}, {}>", key_data.value, value_data.value),
+                generics: generics,
                 libraries,
             }
         }
         // For now we treat interfaces as a generic JSON value and make callers
         // deal with it.
-        GoType::InterfaceType => {
+        GoType::InterfaceType | GoType::JsonRawType => {
             let mut libraries = HashSet::new();
             libraries.insert("serde_json::Value".to_string());
-            RustType {
-                annotations: vec![],
-                value: "Value".to_string(),
-                libraries,
-            }
-        }
-        GoType::JsonRawType => {
-            let mut libraries = HashSet::new();
-            libraries.insert("serde_json::Value".to_string());
-            RustType {
-                annotations: vec![],
-                value: "Value".to_string(),
-                libraries,
+
+            match generic_counter {
+                Some(mut counter) => {
+                    *counter = *counter + 1;
+                    let next_generic = format!("T{}", counter);
+
+                    libraries.insert("serde::de::DeserializeOwned".to_string());
+                    libraries.insert("serde::ser::Serialize".to_string());
+
+                    RustType {
+                        annotations: vec!["#[serde(bound=\"\")]".to_string()],
+                        value: next_generic.clone(),
+                        generics: vec![RustGeneric {
+                            value: next_generic.clone(),
+                            default: Some("Value".to_string()),
+                            bounds: vec![
+                                "DeserializeOwned".to_string(),
+                                "Serialize".to_string(),
+                            ],
+                        }],
+                        libraries,
+                    }
+                }
+                None => {
+                    RustType {
+                        annotations: vec![],
+                        value: "Value".to_string(),
+                        generics: vec![],
+                        libraries,
+                    }
+                }
             }
         }
         GoType::TimestampSecondsType => {
@@ -708,6 +776,7 @@ fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
             RustType {
                 annotations: vec![],
                 value: "SecondTimestamp".to_string(),
+                generics: vec![],
                 libraries,
             }
         }
@@ -718,6 +787,7 @@ fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
             RustType {
                 annotations: vec![],
                 value: "MillisecondTimestamp".to_string(),
+                generics: vec![],
                 libraries,
             }
         }
@@ -731,6 +801,7 @@ fn translate_go_type_to_rust_type(go_type: GoType) -> Result<RustType, Error> {
             RustType {
                 annotations: vec![],
                 value: "DateTime<Utc>".to_string(),
+                generics: vec![],
                 libraries,
             }
         }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -1,19 +1,27 @@
 use chrono::{DateTime, Utc};
 use custom_serde::*;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use super::super::encodings::{Base64Data, MillisecondTimestamp, SecondTimestamp};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct SimpleEmailMessage {
+pub struct SimpleEmailMessage<T1=Value, T2=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+      T2: DeserializeOwned,
+      T2: Serialize,
+{
     #[serde(rename = "commonHeaders")]
     pub common_headers: SimpleEmailCommonHeaders,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source: Option<String>,
     pub timestamp: DateTime<Utc>,
+    #[serde(bound="")]
     #[serde(rename = "rawJson")]
-    pub raw: Value,
+    pub raw: T1,
     pub destination: Vec<String>,
     pub headers: Vec<SimpleEmailHeader>,
     #[serde(rename = "headersTruncated")]
@@ -30,6 +38,7 @@ pub struct SimpleEmailMessage {
     pub millisecs: MillisecondTimestamp,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    pub detail: HashMap<String, Value>,
+    #[serde(bound="")]
+    pub detail: HashMap<String, T2>,
     pub data: Base64Data,
 }


### PR DESCRIPTION
This allows callers to provide a struct type for the CloudWatchEvent `detail` field and have it automatically deserialised by the runtime.

As an example, here is the skeleton of a lambda I built to receive CloudWatch Events for STS AssumeRole. Previously you’d write this:

```
lambda::start(|input: CloudWatchEvent| {
    let assume_role: AssumeRoleDetail = serde_json::value::from_value(input.detail)?;

    ...
})
```

Now you can write:

```
lambda::start(|input: CloudWatchEvent<AssumeRoleDetail>| {
    ...
})
```

I don’t know of any authoritative source for the detail payloads that we could use to codegen them, but this will let you sub in a specific event in place of the `serde_json::Value` field type.

Fixes https://github.com/srijs/rust-aws-lambda/issues/10

<details>
<summary>struct types for example</summary>

```
#[derive(Deserialize, Serialize, Debug)]
struct UserIdentity {
    arn: String,
    #[serde(rename="userName")]
    user_name: String,
}

#[derive(Deserialize, Serialize, Debug)]
struct RequestParameters {
    #[serde(rename="roleArn")]
    role_arn: String,
}

#[derive(Deserialize, Serialize, Debug)]
struct AssumeRoleDetail {
    #[serde(rename="userIdentity")]
    user_identity: UserIdentity,
    #[serde(rename="requestParameters")]
    request_parameters: RequestParameters,
}
```

</details>

cc @LegNeato 