### PR TITLE
keep original field names for structs

### DIFF
--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [928161204cad89472f9e6b5dd49ce16bc91230de](https://github.com/aws/aws-lambda-go/commit/928161204cad89472f9e6b5dd49ce16bc91230de).
+Generated from commit [dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a](https://github.com/aws/aws-lambda-go/commit/dcf76fe64fb68bc66dd3522c904ccf5ff1b2710a).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -316,15 +316,20 @@ where T1: DeserializeOwned,
 pub struct ApiGatewayCustomAuthorizerPolicy {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
+    #[serde(rename = "Version")]
     pub version: Option<String>,
+    #[serde(rename = "Statement")]
     pub statement: Vec<IamPolicyStatement>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct IamPolicyStatement {
+    #[serde(rename = "Action")]
     pub action: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
+    #[serde(rename = "Effect")]
     pub effect: Option<String>,
+    #[serde(rename = "Resource")]
     pub resource: Vec<String>,
 }

--- a/aws_lambda_events/src/generated/code_commit.rs
+++ b/aws_lambda_events/src/generated/code_commit.rs
@@ -57,6 +57,8 @@ pub struct CodeCommitRecord {
     pub aws_region: Option<String>,
     #[serde(rename = "eventTotalParts")]
     pub event_total_parts: u64,
+    #[serde(rename = "customData")]
+    pub custom_data: Option<String>,
 }
 
 /// `CodeCommitCodeCommit` represents a CodeCommit object in a record

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -50,6 +50,7 @@ pub struct CognitoDatasetRecord {
 /// (sign up), allowing a Lambda to perform custom validation to accept or deny the registration request
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEventUserPoolsPreSignup {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
     pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
     pub request: CognitoEventUserPoolsPreSignupRequest,
@@ -60,6 +61,7 @@ pub struct CognitoEventUserPoolsPreSignup {
 /// allowing the Lambda to send custom messages or add custom logic.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEventUserPoolsPostConfirmation {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
     pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
     pub request: CognitoEventUserPoolsPostConfirmationRequest,
@@ -70,6 +72,7 @@ pub struct CognitoEventUserPoolsPostConfirmation {
 /// credentials, allowing a Lambda to perform insert, supress or override claims
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEventUserPoolsPreTokenGen {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
     pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
     pub request: CognitoEventUserPoolsPreTokenGenRequest,

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -278,6 +278,7 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
     for f in fields {
         // Translate the name.
         let member_name = mangle(&f.name.to_snake_case());
+        let go_member_name = mangle(&f.name);
 
         let mut rust_data = translate_go_type_to_rust_type(f.go_type, Some(&mut generics))?;
         let mut rust_type = rust_data.value;
@@ -315,6 +316,12 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
                 rust_data
                     .annotations
                     .push(format!("#[serde(rename = \"{}\")]", rename));
+            }
+        } else {
+            if member_name != go_member_name {
+                rust_data
+                    .annotations
+                    .push(format!("#[serde(rename = \"{}\")]", go_member_name));
             }
         }
 


### PR DESCRIPTION
While developing custom authorizer for lambda API gateway I found that some field names don't match [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html#api-gateway-lambda-authorizer-token-control-lambda-function). 

It looks like `aws-lambda-go` has correct field name. I've tried to adjust parsing logic so that original field names are kept as is. 