### PR TITLE
Fix codegen for aws-lambda-go <= v1.15.0

### DIFF
--- a/aws_lambda_events/src/custom_serde.rs
+++ b/aws_lambda_events/src/custom_serde.rs
@@ -147,7 +147,7 @@ where
 {
     let seconds = duration.num_seconds();
 
-    serializer.serialize_str(&seconds.to_string())
+    serializer.serialize_i64(seconds)
 }
 
 pub(crate) fn deserialize_duration_seconds<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -167,7 +167,7 @@ where
 {
     let minutes = duration.num_minutes();
 
-    serializer.serialize_str(&minutes.to_string())
+    serializer.serialize_i64(minutes)
 }
 
 pub(crate) fn deserialize_duration_minutes<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -349,5 +349,79 @@ mod test {
         });
         let decoded: Test = serde_json::from_value(input).unwrap();
         assert_eq!(HashMap::new(), decoded.v);
+    }
+
+    #[test]
+    fn test_deserialize_duration_seconds() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(deserialize_with = "deserialize_duration_seconds")]
+            v: Duration,
+        }
+
+        let expected = Duration::seconds(36);
+
+        let data = json!({
+                "v": 36,
+            });
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        assert_eq!(expected, decoded.v,);
+
+        let data = json!({
+            "v": 36.1,
+        });
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        assert_eq!(expected, decoded.v,);
+    }
+
+    #[test]
+    fn test_serialize_duration_seconds() {
+        #[derive(Serialize)]
+        struct Test {
+            #[serde(serialize_with = "serialize_duration_seconds")]
+            v: Duration,
+        }
+        let instance = Test {
+            v: Duration::seconds(36),
+        };
+        let encoded = serde_json::to_string(&instance).unwrap();
+        assert_eq!(encoded, String::from(r#"{"v":36}"#));
+    }
+
+    #[test]
+    fn test_deserialize_duration_minutes() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(deserialize_with = "deserialize_duration_minutes")]
+            v: Duration,
+        }
+
+        let expected = Duration::minutes(36);
+
+        let data = json!({
+                "v": 36,
+            });
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        assert_eq!(expected, decoded.v,);
+
+        let data = json!({
+            "v": 36.1,
+        });
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        assert_eq!(expected, decoded.v,);
+    }
+
+    #[test]
+    fn test_serialize_duration_minutes() {
+        #[derive(Serialize)]
+        struct Test {
+            #[serde(serialize_with = "serialize_duration_minutes")]
+            v: Duration,
+        }
+        let instance = Test {
+            v: Duration::minutes(36),
+        };
+        let encoded = serde_json::to_string(&instance).unwrap();
+        assert_eq!(encoded, String::from(r#"{"v":36}"#));
     }
 }

--- a/aws_lambda_events/src/custom_serde.rs
+++ b/aws_lambda_events/src/custom_serde.rs
@@ -1,5 +1,5 @@
 use base64::{decode, encode};
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration, TimeZone, Utc};
 use serde;
 use serde::de::{Deserialize, Deserializer, Error as DeError};
 use serde::ser::Serializer;
@@ -136,6 +136,46 @@ where
     // https://github.com/serde-rs/serde/issues/1098
     let opt = Option::deserialize(deserializer)?;
     Ok(opt.unwrap_or(HashMap::default()))
+}
+
+pub(crate) fn serialize_duration_seconds<S>(
+    duration: &Duration,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let seconds = duration.num_seconds();
+
+    serializer.serialize_str(&seconds.to_string())
+}
+
+pub(crate) fn deserialize_duration_seconds<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let seconds = f64::deserialize(deserializer)?;
+    Ok(Duration::seconds(seconds as i64))
+}
+
+pub(crate) fn serialize_duration_minutes<S>(
+    duration: &Duration,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let minutes = duration.num_minutes();
+
+    serializer.serialize_str(&minutes.to_string())
+}
+
+pub(crate) fn deserialize_duration_minutes<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let minutes = f64::deserialize(deserializer)?;
+    Ok(Duration::minutes(minutes as i64))
 }
 
 #[cfg(test)]

--- a/aws_lambda_events/src/encodings.rs
+++ b/aws_lambda_events/src/encodings.rs
@@ -1,5 +1,5 @@
 use super::custom_serde::*;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use std::ops::{Deref, DerefMut};
 
 /// Binary data encoded in base64.
@@ -63,6 +63,50 @@ impl Deref for SecondTimestamp {
 }
 
 impl DerefMut for SecondTimestamp {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Duration with second precision.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct SecondDuration(
+    #[serde(deserialize_with = "deserialize_duration_seconds")]
+    #[serde(serialize_with = "serialize_duration_seconds")]
+    pub Duration,
+);
+
+impl Deref for SecondDuration {
+    type Target = Duration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SecondDuration {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Duration with minute precision.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct MinuteDuration(
+    #[serde(deserialize_with = "deserialize_duration_minutes")]
+    #[serde(serialize_with = "serialize_duration_minutes")]
+    pub Duration,
+);
+
+impl Deref for MinuteDuration {
+    type Target = Duration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for MinuteDuration {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [08d251dc58f204411d79012fd6f1beefb7107fea](https://github.com/aws/aws-lambda-go/commit/08d251dc58f204411d79012fd6f1beefb7107fea).
+Generated from commit [dd655543f8ce6e2aaf565987263c137f9e6c9802](https://github.com/aws/aws-lambda-go/commit/dd655543f8ce6e2aaf565987263c137f9e6c9802).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -85,6 +85,8 @@ where T1: DeserializeOwned,
     #[serde(default)]
     #[serde(rename = "resourceId")]
     pub resource_id: Option<String>,
+    #[serde(rename = "operationName")]
+    pub operation_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
@@ -134,6 +136,10 @@ pub struct ApiGatewayRequestIdentity {
     #[serde(default)]
     #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "apiKeyId")]
+    pub api_key_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "accessKey")]
@@ -457,6 +463,7 @@ pub struct ApiGatewayCustomAuthorizerPolicy {
     pub statement: Vec<IamPolicyStatement>,
 }
 
+/// `IamPolicyStatement` represents one statement from IAM policy with action, effect and resource
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct IamPolicyStatement {
     #[serde(rename = "Action")]

--- a/aws_lambda_events/src/generated/chime_bot.rs
+++ b/aws_lambda_events/src/generated/chime_bot.rs
@@ -1,0 +1,56 @@
+use chrono::{DateTime, Utc};
+use custom_serde::*;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ChimeBotEvent {
+    #[serde(rename = "Sender")]
+    pub sender: ChimeBotEventSender,
+    #[serde(rename = "Discussion")]
+    pub discussion: ChimeBotEventDiscussion,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "EventType")]
+    pub event_type: Option<String>,
+    #[serde(rename = "InboundHttpsEndpoint")]
+    pub inbound_https_endpoint: Option<ChimeBotEventInboundHttpsEndpoint>,
+    #[serde(rename = "EventTimestamp")]
+    pub event_timestamp: DateTime<Utc>,
+    #[serde(rename = "Message")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ChimeBotEventSender {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "SenderId")]
+    pub sender_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "SenderIdType")]
+    pub sender_id_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ChimeBotEventDiscussion {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "DiscussionId")]
+    pub discussion_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "DiscussionType")]
+    pub discussion_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ChimeBotEventInboundHttpsEndpoint {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "EndpointType")]
+    pub endpoint_type: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "Url")]
+    pub url: Option<String>,
+}

--- a/aws_lambda_events/src/generated/cloudwatch_logs.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_logs.rs
@@ -40,7 +40,7 @@ pub struct CloudwatchLogsData {
     pub log_events: Vec<CloudwatchLogsLogEvent>,
 }
 
-/// LogEvent represents a log entry from cloudwatch logs
+/// `CloudwatchLogsLogEvent` represents a log entry from cloudwatch logs
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CloudwatchLogsLogEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events/src/generated/code_commit.rs
+++ b/aws_lambda_events/src/generated/code_commit.rs
@@ -10,7 +10,7 @@ pub struct CodeCommitEvent {
 
 pub type CodeCommitEventTime = DateTime<Utc>;
 
-/// represents a CodeCommit record
+/// `CodeCommitRecord` represents a CodeCommit record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodeCommitRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events/src/generated/codebuild.rs
+++ b/aws_lambda_events/src/generated/codebuild.rs
@@ -1,0 +1,216 @@
+use chrono::{DateTime, Utc};
+use custom_serde::*;
+use super::super::encodings::{SecondDuration, MinuteDuration};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json::Value;
+
+pub type CodeBuildPhaseStatus = String;
+
+pub type CodeBuildPhaseType = String;
+
+/// `CodeBuildEvent` is documented at:
+/// https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html#sample-build-notifications-ref
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildEvent {
+    /// AccountID is the id of the AWS account from which the event originated.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "account")]
+    pub account_id: Option<String>,
+    /// Region is the AWS region from which the event originated.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub region: Option<String>,
+    /// DetailType informs the schema of the Detail field. For build state-change
+    /// events, the value will be CodeBuildStateChangeDetailType. For phase-change
+    /// events, it will be CodeBuildPhaseChangeDetailType.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "detail-type")]
+    pub detail_type: Option<String>,
+    /// Source should be equal to CodeBuildEventSource.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Version is the version of the event's schema.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Time is the event's timestamp.
+    pub time: DateTime<Utc>,
+    /// ID is the GUID of this event.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Resources is a list of ARNs of CodeBuild builds that this event pertains to.
+    pub resources: Vec<String>,
+    /// Detail contains information specific to a build state-change or
+    /// build phase-change event.
+    pub detail: CodeBuildEventDetail,
+}
+
+/// `CodeBuildEventDetail` represents the all details related to the code build event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildEventDetail {
+    #[serde(rename = "build-status")]
+    pub build_status: CodeBuildPhaseStatus,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "project-name")]
+    pub project_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "build-id")]
+    pub build_id: Option<String>,
+    #[serde(rename = "additional-information")]
+    pub additional_information: CodeBuildEventAdditionalInformation,
+    #[serde(rename = "current-phase")]
+    pub current_phase: CodeBuildPhaseStatus,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "current-phase-context")]
+    pub current_phase_context: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(rename = "completed-phase-status")]
+    pub completed_phase_status: CodeBuildPhaseStatus,
+    #[serde(rename = "completed-phase")]
+    pub completed_phase: CodeBuildPhaseStatus,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "completed-phase-context")]
+    pub completed_phase_context: Option<String>,
+    #[serde(rename = "completed-phase-duration-seconds")]
+    pub completed_phase_duration: SecondDuration,
+    #[serde(rename = "completed-phase-start")]
+    pub completed_phase_start: CodeBuildTime,
+    #[serde(rename = "completed-phase-end")]
+    pub completed_phase_end: CodeBuildTime,
+}
+
+/// `CodeBuildEventAdditionalInformation` represents additional informations to the code build event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildEventAdditionalInformation {
+    pub artifact: CodeBuildArtifact,
+    pub environment: CodeBuildEnvironment,
+    #[serde(rename = "timeout-in-minutes")]
+    pub timeout: MinuteDuration,
+    #[serde(rename = "build-complete")]
+    pub build_complete: bool,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub initiator: Option<String>,
+    #[serde(rename = "build-start-time")]
+    pub build_start_time: CodeBuildTime,
+    pub source: CodeBuildSource,
+    pub logs: CodeBuildLogs,
+    pub phases: Vec<CodeBuildPhase>,
+}
+
+/// `CodeBuildArtifact` represents the artifact provided to build
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildArtifact {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "md5sum")]
+    pub md5_sum: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "sha256sum")]
+    pub sha256_sum: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub location: Option<String>,
+}
+
+/// `CodeBuildEnvironment` represents the environment for a build
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildEnvironment {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub image: Option<String>,
+    #[serde(rename = "privileged-mode")]
+    pub privileged_mode: bool,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "compute-type")]
+    pub compute_type: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "type")]
+    pub type_: Option<String>,
+    #[serde(rename = "environment-variables")]
+    pub environment_variables: Vec<CodeBuildEnvironmentVariable>,
+}
+
+/// `CodeBuildEnvironmentVariable` encapsulate environment variables for the code build
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildEnvironmentVariable {
+    /// Name is the name of the environment variable.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Type is PLAINTEXT or PARAMETER_STORE.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "type")]
+    pub type_: Option<String>,
+    /// Value is the value of the environment variable.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+/// `CodeBuildSource` represent the code source will be build
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildSource {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub location: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "type")]
+    pub type_: Option<String>,
+}
+
+/// `CodeBuildLogs` gives the log details of a code build
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildLogs {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "group-name")]
+    pub group_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "stream-name")]
+    pub stream_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "deep-link")]
+    pub deep_link: Option<String>,
+}
+
+/// `CodeBuildPhase` represents the phase of a build and its details
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeBuildPhase<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
+    #[serde(bound="")]
+    #[serde(rename = "phase-context")]
+    pub phase_context: Vec<T1>,
+    #[serde(rename = "start-time")]
+    pub start_time: CodeBuildTime,
+    #[serde(rename = "end-time")]
+    pub end_time: CodeBuildTime,
+    #[serde(rename = "duration-in-seconds")]
+    pub duration: SecondDuration,
+    #[serde(rename = "phase-type")]
+    pub phase_type: CodeBuildPhaseType,
+    #[serde(rename = "phase-status")]
+    pub phase_status: CodeBuildPhaseStatus,
+}
+
+pub type CodeBuildTime = DateTime<Utc>;

--- a/aws_lambda_events/src/generated/codedeploy.rs
+++ b/aws_lambda_events/src/generated/codedeploy.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Utc};
+use custom_serde::*;
+
+pub type CodeDeployDeploymentState = String;
+
+/// `CodeDeployEvent` is documented at:
+/// https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#acd_event_types
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeDeployEvent {
+    /// AccountID is the id of the AWS account from which the event originated.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "account")]
+    pub account_id: Option<String>,
+    /// Region is the AWS region from which the event originated.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub region: Option<String>,
+    /// DetailType informs the schema of the Detail field. For deployment state-change
+    /// events, the value should be equal to CodeDeployDeploymentEventDetailType.
+    /// For instance state-change events, the value should be equal to
+    /// CodeDeployInstanceEventDetailType.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "detail-type")]
+    pub detail_type: Option<String>,
+    /// Source should be equal to CodeDeployEventSource.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Version is the version of the event's schema.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Time is the event's timestamp.
+    pub time: DateTime<Utc>,
+    /// ID is the GUID of this event.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Resources is a list of ARNs of CodeDeploy applications and deployment
+    /// groups that this event pertains to.
+    pub resources: Vec<String>,
+    /// Detail contains information specific to a deployment event.
+    pub detail: CodeDeployEventDetail,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CodeDeployEventDetail {
+    /// InstanceGroupID is the ID of the instance group.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "instanceGroupId")]
+    pub instance_group_id: Option<String>,
+    /// InstanceID is the id of the instance. This field is non-empty only if
+    /// the DetailType of the complete event is CodeDeployInstanceEventDetailType.
+    #[serde(rename = "instanceId")]
+    pub instance_id: Option<String>,
+    /// Region is the AWS region that the event originated from.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub region: Option<String>,
+    /// Application is the name of the CodeDeploy application.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub application: Option<String>,
+    /// DeploymentID is the id of the deployment.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "deploymentId")]
+    pub deployment_id: Option<String>,
+    /// State is the new state of the deployment.
+    pub state: CodeDeployDeploymentState,
+    /// DeploymentGroup is the name of the deployment group.
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "deploymentGroup")]
+    pub deployment_group: Option<String>,
+}

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -57,6 +57,17 @@ pub struct CognitoEventUserPoolsPreSignup {
     pub response: CognitoEventUserPoolsPreSignupResponse,
 }
 
+/// `CognitoEventUserPoolsPreAuthentication` is sent by AWS Cognito User Pools when a user submits their information
+/// to be authenticated, allowing you to perform custom validations to accept or deny the sign in request.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPreAuthentication {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub request: CognitoEventUserPoolsPreAuthenticationRequest,
+    pub response: CognitoEventUserPoolsPreAuthenticationResponse,
+}
+
 /// `CognitoEventUserPoolsPostConfirmation` is sent by AWS Cognito User Pools after a user is confirmed,
 /// allowing the Lambda to send custom messages or add custom logic.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -69,7 +80,7 @@ pub struct CognitoEventUserPoolsPostConfirmation {
 }
 
 /// `CognitoEventUserPoolsPreTokenGen` is sent by AWS Cognito User Pools when a user attempts to retrieve
-/// credentials, allowing a Lambda to perform insert, supress or override claims
+/// credentials, allowing a Lambda to perform insert, suppress or override claims
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEventUserPoolsPreTokenGen {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
@@ -77,6 +88,32 @@ pub struct CognitoEventUserPoolsPreTokenGen {
     pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
     pub request: CognitoEventUserPoolsPreTokenGenRequest,
     pub response: CognitoEventUserPoolsPreTokenGenResponse,
+}
+
+/// `CognitoEventUserPoolsPostAuthentication` is sent by AWS Cognito User Pools after a user is authenticated,
+/// allowing the Lambda to add custom logic.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPostAuthentication {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub request: CognitoEventUserPoolsPostAuthenticationRequest,
+    pub response: CognitoEventUserPoolsPostAuthenticationResponse,
+}
+
+/// `CognitoEventUserPoolsMigrateUser` is sent by AWS Cognito User Pools when a user does not exist in the
+/// user pool at the time of sign-in with a password, or in the forgot-password flow.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsMigrateUser {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    #[serde(rename = "request")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_migrate_user_request: CognitoEventUserPoolsMigrateUserRequest,
+    #[serde(rename = "response")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_migrate_user_response: CognitoEventUserPoolsMigrateUserResponse,
 }
 
 /// `CognitoEventUserPoolsCallerContext` contains information about the caller
@@ -128,6 +165,10 @@ pub struct CognitoEventUserPoolsPreSignupRequest {
     #[serde(default)]
     #[serde(rename = "validationData")]
     pub validation_data: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "clientMetadata")]
+    pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsPreSignupResponse` contains the response portion of a PreSignup event
@@ -141,6 +182,23 @@ pub struct CognitoEventUserPoolsPreSignupResponse {
     pub auto_verify_phone: bool,
 }
 
+/// `CognitoEventUserPoolsPreAuthenticationRequest` contains the request portion of a PreAuthentication event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPreAuthenticationRequest {
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "userAttributes")]
+    pub user_attributes: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "validationData")]
+    pub validation_data: HashMap<String, String>,
+}
+
+/// `CognitoEventUserPoolsPreAuthenticationResponse` contains the response portion of a PreAuthentication event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPreAuthenticationResponse;
+
 /// `CognitoEventUserPoolsPostConfirmationRequest` contains the request portion of a PostConfirmation event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CognitoEventUserPoolsPostConfirmationRequest {
@@ -148,6 +206,10 @@ pub struct CognitoEventUserPoolsPostConfirmationRequest {
     #[serde(default)]
     #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "clientMetadata")]
+    pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsPostConfirmationResponse` contains the response portion of a PostConfirmation event
@@ -163,6 +225,10 @@ pub struct CognitoEventUserPoolsPreTokenGenRequest {
     pub user_attributes: HashMap<String, String>,
     #[serde(rename = "groupConfiguration")]
     pub group_configuration: GroupConfiguration,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "clientMetadata")]
+    pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsPreTokenGenResponse` containst the response portion of  a PreTokenGen event
@@ -172,7 +238,59 @@ pub struct CognitoEventUserPoolsPreTokenGenResponse {
     pub claims_override_details: ClaimsOverrideDetails,
 }
 
-/// `ClaimsOverrideDetails` allows lambda to add, supress or override claims in the token
+/// `CognitoEventUserPoolsPostAuthenticationRequest` contains the request portion of a PostAuthentication event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPostAuthenticationRequest {
+    #[serde(rename = "newDeviceUsed")]
+    pub new_device_used: bool,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "userAttributes")]
+    pub user_attributes: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "clientMetadata")]
+    pub client_metadata: HashMap<String, String>,
+}
+
+/// `CognitoEventUserPoolsPostAuthenticationResponse` contains the response portion of a PostAuthentication event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsPostAuthenticationResponse;
+
+/// `CognitoEventUserPoolsMigrateUserRequest` contains the request portion of a MigrateUser event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsMigrateUserRequest {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub password: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "clientMetadata")]
+    pub client_metadata: HashMap<String, String>,
+}
+
+/// `CognitoEventUserPoolsMigrateUserResponse` contains the response portion of a MigrateUser event
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsMigrateUserResponse {
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "userAttributes")]
+    pub user_attributes: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "finalUserStatus")]
+    pub final_user_status: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "messageAction")]
+    pub message_action: Option<String>,
+    #[serde(rename = "desiredDeliveryMediums")]
+    pub desired_delivery_mediums: Vec<String>,
+    #[serde(rename = "forceAliasCreation")]
+    pub force_alias_creation: bool,
+}
+
+/// `ClaimsOverrideDetails` allows lambda to add, suppress or override claims in the token
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ClaimsOverrideDetails {
     #[serde(rename = "groupOverrideDetails")]
@@ -194,6 +312,22 @@ pub struct GroupConfiguration {
     pub iam_roles_to_override: Vec<String>,
     #[serde(rename = "preferredRole")]
     pub preferred_role: Option<String>,
+}
+
+/// `CognitoEventUserPoolsChallengeResult` represents a challenge that is presented to the user in the authentication
+/// process that is underway, along with the corresponding result.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CognitoEventUserPoolsChallengeResult {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "challengeName")]
+    pub challenge_name: Option<String>,
+    #[serde(rename = "challengeResult")]
+    pub challenge_result: bool,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "challengeMetadata")]
+    pub challenge_metadata: Option<String>,
 }
 
 #[cfg(test)]

--- a/aws_lambda_events/src/generated/firehose.rs
+++ b/aws_lambda_events/src/generated/firehose.rs
@@ -14,6 +14,10 @@ pub struct KinesisFirehoseEvent {
     pub delivery_stream_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
+    #[serde(rename = "sourceKinesisStreamArn")]
+    pub source_kinesis_stream_arn: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
     pub region: Option<String>,
     pub records: Vec<KinesisFirehoseEventRecord>,
 }
@@ -27,6 +31,8 @@ pub struct KinesisFirehoseEventRecord {
     #[serde(rename = "approximateArrivalTimestamp")]
     pub approximate_arrival_timestamp: MillisecondTimestamp,
     pub data: Base64Data,
+    #[serde(rename = "kinesisRecordMetadata")]
+    pub kinesis_firehose_record_metadata: KinesisFirehoseRecordMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -45,6 +51,26 @@ pub struct KinesisFirehoseResponseRecord {
     #[serde(default)]
     pub result: Option<String>,
     pub data: Base64Data,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct KinesisFirehoseRecordMetadata {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "shardId")]
+    pub shard_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "partitionKey")]
+    pub partition_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "sequenceNumber")]
+    pub sequence_number: Option<String>,
+    #[serde(rename = "subsequenceNumber")]
+    pub subsequence_number: i64,
+    #[serde(rename = "approximateArrivalTimestamp")]
+    pub approximate_arrival_timestamp: MillisecondTimestamp,
 }
 
 #[cfg(test)]

--- a/aws_lambda_events/src/generated/fixtures/example-firehose-event.json
+++ b/aws_lambda_events/src/generated/fixtures/example-firehose-event.json
@@ -1,6 +1,7 @@
 {
    "invocationId": "invoked123",
    "deliveryStreamArn": "aws:lambda:events",
+   "sourceKinesisStreamArn": "arn:aws:kinesis:us-east-1:123456789012:stream/test",
    "region": "us-west-2",
    "records": [
      {
@@ -10,9 +11,9 @@
        "kinesisRecordMetadata": {
          "shardId": "shardId-000000000000",
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c317a",
-         "approximateArrivalTimestamp": "1507217624302",
+         "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785154",
-         "subsequenceNumber": ""
+         "subsequenceNumber": 123456
        }
      },
      {
@@ -22,10 +23,11 @@
        "kinesisRecordMetadata": {
          "shardId": "shardId-000000000001",
          "partitionKey": "4d1ad2b9-24f8-4b9d-a088-76e9947c318a",
-         "approximateArrivalTimestamp": "1507217624302",
+         "approximateArrivalTimestamp": 1507217624302,
          "sequenceNumber": "49546986683135544286507457936321625675700192471156785155",
-         "subsequenceNumber": ""
+         "subsequenceNumber": 123457
        }
      }
    ]
  }
+

--- a/aws_lambda_events/src/generated/lex.rs
+++ b/aws_lambda_events/src/generated/lex.rs
@@ -11,10 +11,8 @@ pub struct LexEvent {
     pub user_id: Option<String>,
     #[serde(rename = "inputTranscript")]
     pub input_transcript: Option<String>,
-    #[serde(deserialize_with = "deserialize_lambda_map")]
-    #[serde(default)]
     #[serde(rename = "sessionAttributes")]
-    pub session_attributes: HashMap<String, String>,
+    pub session_attributes: Option<SessionAttributes>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(rename = "requestAttributes")]
@@ -72,7 +70,17 @@ pub struct LexDialogAction {
     pub response_card: Option<LexResponseCard>,
 }
 
+pub type SessionAttributes = HashMap<String, String>;
+
 pub type Slots = HashMap<String, Option<String>>;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct LexResponse {
+    #[serde(rename = "sessionAttributes")]
+    pub session_attributes: SessionAttributes,
+    #[serde(rename = "dialogAction")]
+    pub dialog_action: Option<LexDialogAction>,
+}
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct LexResponseCard {

--- a/aws_lambda_events/src/generated/mod.rs
+++ b/aws_lambda_events/src/generated/mod.rs
@@ -6,12 +6,18 @@ pub mod apigw;
 pub mod appsync;
 /// AWS Lambda event definitions for autoscaling.
 pub mod autoscaling;
+/// AWS Lambda event definitions for chime_bot.
+pub mod chime_bot;
 /// AWS Lambda event definitions for cloudwatch_events.
 pub mod cloudwatch_events;
 /// AWS Lambda event definitions for cloudwatch_logs.
 pub mod cloudwatch_logs;
 /// AWS Lambda event definitions for code_commit.
 pub mod code_commit;
+/// AWS Lambda event definitions for codebuild.
+pub mod codebuild;
+/// AWS Lambda event definitions for codedeploy.
+pub mod codedeploy;
 /// AWS Lambda event definitions for codepipeline_job.
 pub mod codepipeline_job;
 /// AWS Lambda event definitions for cognito.
@@ -32,6 +38,8 @@ pub mod kinesis_analytics;
 pub mod lex;
 /// AWS Lambda event definitions for s3.
 pub mod s3;
+/// AWS Lambda event definitions for s3_batch_job.
+pub mod s3_batch_job;
 /// AWS Lambda event definitions for ses.
 pub mod ses;
 /// AWS Lambda event definitions for sns.

--- a/aws_lambda_events/src/generated/s3.rs
+++ b/aws_lambda_events/src/generated/s3.rs
@@ -2,12 +2,14 @@ use chrono::{DateTime, Utc};
 use custom_serde::*;
 use std::collections::HashMap;
 
+/// `S3Event` which wrap an array of `S3Event`Record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3Event {
     #[serde(rename = "Records")]
     pub records: Vec<S3EventRecord>,
 }
 
+/// `S3EventRecord` which wrap record data
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct S3EventRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events/src/generated/s3_batch_job.rs
+++ b/aws_lambda_events/src/generated/s3_batch_job.rs
@@ -1,0 +1,80 @@
+use custom_serde::*;
+
+/// `S3BatchJobEvent` encapsulates the detail of a s3 batch job
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct S3BatchJobEvent {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "invocationSchemaVersion")]
+    pub invocation_schema_version: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "invocationId")]
+    pub invocation_id: Option<String>,
+    pub job: S3BatchJob,
+    pub tasks: Vec<S3BatchJobTask>,
+}
+
+/// `S3BatchJob` whichs have the job id
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct S3BatchJob {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// `S3BatchJobTask` represents one task in the s3 batch job and have all task details
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct S3BatchJobTask {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "taskId")]
+    pub task_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "s3Key")]
+    pub s3_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "s3VersionId")]
+    pub s3_version_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "s3BucketArn")]
+    pub s3_bucket_arn: Option<String>,
+}
+
+/// `S3BatchJobResponse` is the response of a iven s3 batch job with the results
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct S3BatchJobResponse {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "invocationSchemaVersion")]
+    pub invocation_schema_version: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "treatMissingKeysAs")]
+    pub treat_missing_keys_as: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "invocationId")]
+    pub invocation_id: Option<String>,
+    pub results: Vec<S3BatchJobResult>,
+}
+
+/// `S3BatchJobResult` represents the result of a given task
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct S3BatchJobResult {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "taskId")]
+    pub task_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "resultCode")]
+    pub result_code: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "resultString")]
+    pub result_string: Option<String>,
+}

--- a/aws_lambda_events/src/generated/ses.rs
+++ b/aws_lambda_events/src/generated/ses.rs
@@ -98,20 +98,34 @@ pub struct SimpleEmailCommonHeaders {
     pub subject: Option<String>,
 }
 
+/// `SimpleEmailReceiptAction` is a logical union of fields present in all action
+/// Types. For example, the FunctionARN and InvocationType fields are only
+/// present for the Lambda Type, and the BucketName and ObjectKey fields are only
+/// present for the S3 Type.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailReceiptAction {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "type")]
     pub type_: Option<String>,
-    #[serde(deserialize_with = "deserialize_lambda_string")]
-    #[serde(default)]
+    #[serde(rename = "topicArn")]
+    pub topic_arn: Option<String>,
+    #[serde(rename = "bucketName")]
+    pub bucket_name: Option<String>,
+    #[serde(rename = "objectKey")]
+    pub object_key: Option<String>,
+    #[serde(rename = "smtpReplyCode")]
+    pub smtp_reply_code: Option<String>,
+    #[serde(rename = "statusCode")]
+    pub status_code: Option<String>,
+    pub message: Option<String>,
+    pub sender: Option<String>,
     #[serde(rename = "invocationType")]
     pub invocation_type: Option<String>,
-    #[serde(deserialize_with = "deserialize_lambda_string")]
-    #[serde(default)]
     #[serde(rename = "functionArn")]
     pub function_arn: Option<String>,
+    #[serde(rename = "organizationArn")]
+    pub organization_arn: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -127,20 +141,4 @@ pub type SimpleEmailDispositionValue = String;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct SimpleEmailDisposition {
     pub disposition: SimpleEmailDispositionValue,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    extern crate serde_json;
-
-    #[test]
-    fn example_event() {
-        let data = include_bytes!("fixtures/example-ses-event.json");
-        let parsed: SimpleEmailEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SimpleEmailEvent = serde_json::from_slice(output.as_bytes()).unwrap();
-        assert_eq!(parsed, reparsed);
-    }
 }

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -540,6 +540,9 @@ enum GoType {
     TimestampMillisecondsType,
     TimestampSecondsType,
     JsonRawType,
+    DurationType,
+    DurationSecondsType,
+    DurationMinutesType,
 }
 
 struct RustType {
@@ -662,6 +665,8 @@ fn parse_go_ident(t: &str) -> Result<GoType, Error> {
     match t {
         "MilliSecondsEpochTime" => Ok(GoType::TimestampMillisecondsType),
         "SecondsEpochTime" => Ok(GoType::TimestampSecondsType),
+        "DurationSeconds" => Ok(GoType::DurationSecondsType),
+        "DurationMinutes" => Ok(GoType::DurationMinutesType),
         _ => Ok(GoType::UserDefined(t.to_string())),
     }
 }
@@ -670,6 +675,7 @@ fn parse_go_package_ident(t: &str) -> Result<GoType, Error> {
     match t {
         "time.Time" => Ok(GoType::TimeType),
         "json.RawMessage" => Ok(GoType::JsonRawType),
+        "time.Duration" => Ok(GoType::DurationType),
         _ => unimplemented!("missing go package ident mapping: {}", t),
     }
 }
@@ -837,6 +843,36 @@ fn translate_go_type_to_rust_type(go_type: GoType, generic_counter: Option<&mut 
             RustType {
                 annotations: vec![],
                 value: "DateTime<Utc>".to_string(),
+                generics: vec![],
+                libraries,
+            }
+        }
+        GoType::DurationType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("super::super::encodings::Duration".to_string());
+            RustType {
+                annotations: vec![],
+                value: "Duration".to_string(),
+                generics: vec![],
+                libraries,
+            }
+        }
+        GoType::DurationSecondsType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("super::super::encodings::SecondDuration".to_string());
+            RustType {
+                annotations: vec![],
+                value: "SecondDuration".to_string(),
+                generics: vec![],
+                libraries,
+            }
+        }
+        GoType::DurationMinutesType => {
+            let mut libraries = HashSet::new();
+            libraries.insert("super::super::encodings::MinuteDuration".to_string());
+            RustType {
+                annotations: vec![],
+                value: "MinuteDuration".to_string(),
                 generics: vec![],
                 libraries,
             }

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -540,7 +540,6 @@ enum GoType {
     TimestampMillisecondsType,
     TimestampSecondsType,
     JsonRawType,
-    DurationType,
     DurationSecondsType,
     DurationMinutesType,
 }
@@ -675,7 +674,6 @@ fn parse_go_package_ident(t: &str) -> Result<GoType, Error> {
     match t {
         "time.Time" => Ok(GoType::TimeType),
         "json.RawMessage" => Ok(GoType::JsonRawType),
-        "time.Duration" => Ok(GoType::DurationType),
         _ => unimplemented!("missing go package ident mapping: {}", t),
     }
 }
@@ -843,16 +841,6 @@ fn translate_go_type_to_rust_type(go_type: GoType, generic_counter: Option<&mut 
             RustType {
                 annotations: vec![],
                 value: "DateTime<Utc>".to_string(),
-                generics: vec![],
-                libraries,
-            }
-        }
-        GoType::DurationType => {
-            let mut libraries = HashSet::new();
-            libraries.insert("super::super::encodings::Duration".to_string());
-            RustType {
-                annotations: vec![],
-                value: "Duration".to_string(),
                 generics: vec![],
                 libraries,
             }

--- a/aws_lambda_events_codegen/src/main.rs
+++ b/aws_lambda_events_codegen/src/main.rs
@@ -51,6 +51,8 @@ fn get_blacklist() -> HashSet<String> {
     let mut blacklist = HashSet::new();
     // https://github.com/aws/aws-lambda-go/blob/master/events/attributevalue.go
     blacklist.insert("attributevalue".to_string());
+    // https://github.com/aws/aws-lambda-go/blob/master/events/duration.go
+    blacklist.insert("duration".to_string());
     // https://github.com/aws/aws-lambda-go/blob/master/events/dynamodb.go
     blacklist.insert("dynamodb".to_string());
     // https://github.com/aws/aws-lambda-go/blob/master/events/epoch_time.go


### PR DESCRIPTION
Closes https://github.com/LegNeato/aws-lambda-events/issues/12.

For `aws-lambda-go` v1.16.0 with https://github.com/aws/aws-lambda-go/pull/274 a structure `APIGatewayV2HTTPRequestContext` was added with nested struct definitions which Rust does not support and this code generator cannot handle.

I can open an issue in https://github.com/aws/aws-lambda-go pointing this out and asking for all structs to be defined at the top level.