### PR TITLE
Update to v1.17.0, newer dependencies, and 2018 edition

### DIFF
--- a/aws_lambda_events/Cargo.toml
+++ b/aws_lambda_events/Cargo.toml
@@ -17,12 +17,12 @@ categories = ["api-bindings", "encoding", "web-programming"]
 travis-ci = { repository = "LegNeato/aws-lambda-events" }
 
 [dependencies]
-base64 = "0.9.2"
+base64 = "0.12"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-bytes = { version = "0.4", features = ["serde"] }
-chrono = { version = "0.4.4", features = ["serde"] }
+bytes = { version = "0.5", features = ["serde"] }
+chrono = { version = "^0.4.4", features = ["serde"] }
 
 [dev-dependencies]
-pretty_assertions = "0.5.1"
+pretty_assertions = "0.6"

--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [4e5ba498875ed406722b43a5c603101894df5d2c](https://github.com/aws/aws-lambda-go/commit/4e5ba498875ed406722b43a5c603101894df5d2c).
+Generated from commit [c67fadea00272ce2b8227d4ca900da882b290694](https://github.com/aws/aws-lambda-go/commit/c67fadea00272ce2b8227d4ca900da882b290694).

--- a/aws_lambda_events/src/generated/alb.rs
+++ b/aws_lambda_events/src/generated/alb.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 /// `AlbTargetGroupRequest` contains data originating from the ALB Lambda target group integration

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -93,8 +93,19 @@ where
     pub stage: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
+    #[serde(rename = "domainName")]
+    pub domain_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "domainPrefix")]
+    pub domain_prefix: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
     #[serde(rename = "requestId")]
     pub request_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub protocol: Option<String>,
     pub identity: ApiGatewayRequestIdentity,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -108,6 +119,12 @@ where
     #[serde(default)]
     #[serde(rename = "httpMethod")]
     pub http_method: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "requestTime")]
+    pub request_time: Option<String>,
+    #[serde(rename = "requestTimeEpoch")]
+    pub request_time_epoch: i64,
     /// The API Gateway rest API Id
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/appsync.rs
+++ b/aws_lambda_events/src/generated/appsync.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/chime_bot.rs
+++ b/aws_lambda_events/src/generated/chime_bot.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ChimeBotEvent {

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/cloudwatch_logs.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_logs.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// `CloudwatchLogsEvent` represents raw data from a cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/code_commit.rs
+++ b/aws_lambda_events/src/generated/code_commit.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 
 /// `CodeCommitEvent` represents a CodeCommit event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/codebuild.rs
+++ b/aws_lambda_events/src/generated/codebuild.rs
@@ -1,6 +1,6 @@
 use super::super::encodings::{MinuteDuration, SecondDuration};
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/codedeploy.rs
+++ b/aws_lambda_events/src/generated/codedeploy.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 
 pub type CodeDeployDeploymentState = String;
 

--- a/aws_lambda_events/src/generated/codepipeline_job.rs
+++ b/aws_lambda_events/src/generated/codepipeline_job.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// `CodePipelineEvent` contains data from an event sent from AWS Codepipeline
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 /// `CognitoEvent` contains data from an event sent from AWS Cognito Sync

--- a/aws_lambda_events/src/generated/config.rs
+++ b/aws_lambda_events/src/generated/config.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// `ConfigEvent` contains data from an event sent from AWS Config
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/connect.rs
+++ b/aws_lambda_events/src/generated/connect.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 /// `ConnectEvent` contains the data structure for a Connect event.

--- a/aws_lambda_events/src/generated/firehose.rs
+++ b/aws_lambda_events/src/generated/firehose.rs
@@ -1,5 +1,5 @@
 use super::super::encodings::{Base64Data, MillisecondTimestamp};
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// `KinesisFirehoseEvent` represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/iot_button.rs
+++ b/aws_lambda_events/src/generated/iot_button.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct IoTButtonEvent {

--- a/aws_lambda_events/src/generated/kinesis.rs
+++ b/aws_lambda_events/src/generated/kinesis.rs
@@ -1,5 +1,5 @@
 use super::super::encodings::{Base64Data, SecondTimestamp};
-use custom_serde::*;
+use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct KinesisEvent {

--- a/aws_lambda_events/src/generated/kinesis_analytics.rs
+++ b/aws_lambda_events/src/generated/kinesis_analytics.rs
@@ -1,5 +1,5 @@
 use super::super::encodings::Base64Data;
-use custom_serde::*;
+use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct KinesisAnalyticsOutputDeliveryEvent {

--- a/aws_lambda_events/src/generated/lex.rs
+++ b/aws_lambda_events/src/generated/lex.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/s3.rs
+++ b/aws_lambda_events/src/generated/s3.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 use std::collections::HashMap;
 
 /// `S3Event` which wrap an array of `S3Event`Record

--- a/aws_lambda_events/src/generated/s3_batch_job.rs
+++ b/aws_lambda_events/src/generated/s3_batch_job.rs
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// `S3BatchJobEvent` encapsulates the detail of a s3 batch job
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/ses.rs
+++ b/aws_lambda_events/src/generated/ses.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 
 /// `SimpleEmailEvent` is the outer structure of an event sent via SES.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -1,5 +1,5 @@
+use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
-use custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events/src/generated/sqs.rs
+++ b/aws_lambda_events/src/generated/sqs.rs
@@ -1,5 +1,5 @@
 use super::super::encodings::Base64Data;
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events_codegen/Cargo.toml
+++ b/aws_lambda_events_codegen/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 quicli = "0.2"
-glob = "0.2"
+glob = "0.3"
 go_to_rust = { path = "./go_to_rust" }
 # Needed to pick up a bunch of changes.
 codegen = { git = "https://github.com/LegNeato/codegen.git", branch = "issue-3-and-4-field-documentation-annotation"}

--- a/aws_lambda_events_codegen/Cargo.toml
+++ b/aws_lambda_events_codegen/Cargo.toml
@@ -3,6 +3,7 @@ name = "aws_lambda_events_codegen"
 version = "0.1.1"
 authors = ["Christian Legnitto <christian@legnitto.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 quicli = "0.2"

--- a/aws_lambda_events_codegen/go_to_rust/Cargo.toml
+++ b/aws_lambda_events_codegen/go_to_rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Christian Legnitto <christian@legnitto.com>"]
 build = "build.rs"
 publish = false
+edition = "2018"
 
 [[test]]
 name = "integration"

--- a/aws_lambda_events_codegen/go_to_rust/Cargo.toml
+++ b/aws_lambda_events_codegen/go_to_rust/Cargo.toml
@@ -15,12 +15,12 @@ pest = "^1.0"
 pest_derive = "^1.0"
 # Needed to pick up this PR: https://github.com/carllerche/codegen/pull/6
 codegen = { git = "https://github.com/LegNeato/codegen.git", branch = "issue-3-and-4-field-documentation-annotation"}
-failure = "0.1.1"
-heck = "0.3.0"
-regex = "1.0.1"
-lazy_static = "1.0.1"
+failure = "0.1"
+heck = "0.3"
+regex = "^1.0"
+lazy_static = "^1.0"
 
 [dev-dependencies]
 rustc-test ="0.3"
-glob = "0.2"
-env_logger = "0.5.9"
+glob = "0.3"
+env_logger = "0.7"

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -327,7 +327,7 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
             // Go converts null strings to "" and sometimes is wrong about
             // json string fields that can be `null`. We treat all `String`
             // fields as `Option<String>` and convert `""` to `None`.
-            libraries.insert("custom_serde::*".to_string());
+            libraries.insert("crate::custom_serde::*".to_string());
 
             let mut string_as_option = Field::new(&member_name, "Option<String>");
             string_as_option.annotation(vec![
@@ -337,7 +337,7 @@ fn parse_struct(pairs: Pairs<Rule>) -> Result<(codegen::Struct, HashSet<String>)
             field_defs.push(string_as_option);
         } else if HASHMAP_RE.is_match(&rust_type) {
             // We default to an empty `HashMap` even if the field is `null`.
-            libraries.insert("custom_serde::*".to_string());
+            libraries.insert("crate::custom_serde::*".to_string());
             let mut map_as_empty = Field::new(&member_name, &rust_type);
             map_as_empty.annotation(vec![
                 "#[serde(deserialize_with = \"deserialize_lambda_map\")]",

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/field_doc_comment/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/field_doc_comment/expected.txt
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use custom_serde::*;
+use crate::custom_serde::*;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json::Value;

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
@@ -1,4 +1,4 @@
-use custom_serde::*;
+use crate::custom_serde::*;
 
 /// Foo
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events_codegen/go_to_rust/tests/integration.rs
+++ b/aws_lambda_events_codegen/go_to_rust/tests/integration.rs
@@ -1,6 +1,4 @@
-extern crate env_logger;
-extern crate glob;
-extern crate go_to_rust;
+use go_to_rust;
 extern crate rustc_test as test;
 
 use crate::test::{DynTestFn, DynTestName, TestDesc, TestDescAndFn};

--- a/aws_lambda_events_codegen/go_to_rust/tests/integration.rs
+++ b/aws_lambda_events_codegen/go_to_rust/tests/integration.rs
@@ -3,6 +3,7 @@ extern crate glob;
 extern crate go_to_rust;
 extern crate rustc_test as test;
 
+use crate::test::{DynTestFn, DynTestName, TestDesc, TestDescAndFn};
 use glob::glob;
 use std::env;
 use std::fs::File;
@@ -10,7 +11,6 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::path::Path;
 use std::path::PathBuf;
-use test::{DynTestFn, DynTestName, TestDesc, TestDescAndFn};
 
 fn mk_test(desc: &str, input: String, expect: String, expected_path: PathBuf) -> TestDescAndFn {
     TestDescAndFn {

--- a/aws_lambda_events_codegen/src/main.rs
+++ b/aws_lambda_events_codegen/src/main.rs
@@ -1,7 +1,7 @@
-extern crate go_to_rust;
+use go_to_rust;
 #[macro_use]
 extern crate quicli;
-extern crate codegen;
+use codegen;
 
 use quicli::prelude::*;
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
### Changes

* Update to aws-lambda-go v1.17.0 (minor change to generated code).
* Update to latest versions of most dependencies
  
  Add caret requirements as needed to allow latest minor version of stable crates.
  
  Leaving `quicli` at old version for now due to incompatible changes (and general abandonment) and retaining forked `codegen` copy though upstream could perhaps integrate the local changes now the parent branch has been landed. Updating `pest` to v2 will also involve some api adaptations.
* Update to edition 2018
  
  First run of `cargo fix --edition` and new edition keys.
  
  Includes minor change to code generation to include the `crate::` prefix and regeneration of files.
* Fix 2018 idioms
  
  Run of `cargo fix --edition-idioms` but no change to generated code.

### Motivation

This is getting towards reducing the dependency graph of my new lambda function to have a single copy of more deps. I'm not quite sure what the general rust story here is, but from the [`base64` changelog](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#0110) they've been bumping the minimum required rust version, so seemed to make sense to leap edition when updating that runtime dep.

<details><summary>`cargo tree -p aws_lambda_events` before</summary>

```
aws_lambda_events v0.3.1-pre (.../aws_lambda_events)
├── base64 v0.9.3
│   ├── byteorder v1.3.4
│   └── safemem v0.3.3
├── bytes v0.4.12
│   ├── byteorder v1.3.4
│   ├── iovec v0.1.4
│   │   └── libc v0.2.72
│   └── serde v1.0.114
├── chrono v0.4.13
│   ├── num-integer v0.1.43
│   │   └── num-traits v0.2.12
│   │       [build-dependencies]
│   │       └── autocfg v1.0.0
│   │   [build-dependencies]
│   │   └── autocfg v1.0.0
│   ├── num-traits v0.2.12 (*)
│   ├── serde v1.0.114
│   └── time v0.1.43
│       └── libc v0.2.72
├── serde v1.0.114
├── serde_derive v1.0.114
│   ├── proc-macro2 v1.0.18
│   │   └── unicode-xid v0.2.1
│   ├── quote v1.0.7
│   │   └── proc-macro2 v1.0.18 (*)
│   └── syn v1.0.33
│       ├── proc-macro2 v1.0.18 (*)
│       ├── quote v1.0.7 (*)
│       └── unicode-xid v0.2.1
└── serde_json v1.0.56
    ├── itoa v0.4.6
    ├── ryu v1.0.5
    └── serde v1.0.114
[dev-dependencies]
└── pretty_assertions v0.5.1
    ├── ansi_term v0.11.0
    └── difference v2.0.0
```
</details>

<details><summary>`cargo tree -p aws_lambda_events` after</summary>

```
aws_lambda_events v0.3.1-pre (.../aws_lambda_events)
├── base64 v0.12.3
├── bytes v0.5.5
│   └── serde v1.0.114
├── chrono v0.4.13
│   ├── num-integer v0.1.43
│   │   └── num-traits v0.2.12
│   │       [build-dependencies]
│   │       └── autocfg v1.0.0
│   │   [build-dependencies]
│   │   └── autocfg v1.0.0
│   ├── num-traits v0.2.12 (*)
│   ├── serde v1.0.114
│   └── time v0.1.43
│       └── libc v0.2.72
├── serde v1.0.114
├── serde_derive v1.0.114
│   ├── proc-macro2 v1.0.18
│   │   └── unicode-xid v0.2.1
│   ├── quote v1.0.7
│   │   └── proc-macro2 v1.0.18 (*)
│   └── syn v1.0.33
│       ├── proc-macro2 v1.0.18 (*)
│       ├── quote v1.0.7 (*)
│       └── unicode-xid v0.2.1
└── serde_json v1.0.56
    ├── itoa v0.4.6
    ├── ryu v1.0.5
    └── serde v1.0.114
[dev-dependencies]
└── pretty_assertions v0.6.1
    ├── ansi_term v0.11.0
    └── difference v2.0.0
```
</details>