### PR TITLE
make websocket proxy authorizer optional

### DIFF
--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -404,7 +404,7 @@ where
     #[serde(rename = "resourcePath")]
     pub resource_path: Option<String>,
     #[serde(bound = "")]
-    pub authorizer: T1,
+    pub authorizer: Option<T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "httpMethod")]


### PR DESCRIPTION
The context field `authorizer` may need to be an `Option` as AWS does not pass this field for a WebSocket API proxy request integration if an authorizer is not configured.

Currently results in a serde missing field error in this scenario. This patch fixed for me. Since this is generated code, I'm not certain this direct modification is the right approach.