### PR TITLE
Catchup with current version of aws-lambda-go

### DIFF
--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [c67fadea00272ce2b8227d4ca900da882b290694](https://github.com/aws/aws-lambda-go/commit/c67fadea00272ce2b8227d4ca900da882b290694).
+Generated from commit [f24acb29a08c3a45eb95e6cd4ae56fbfabf4f4a5](https://github.com/aws/aws-lambda-go/commit/f24acb29a08c3a45eb95e6cd4ae56fbfabf4f4a5).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -215,8 +215,17 @@ pub struct ApiGatewayV2httpRequestContext {
 
 /// `ApiGatewayV2httpRequestContextAuthorizerDescription` contains authorizer information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct ApiGatewayV2httpRequestContextAuthorizerDescription {
-    pub jwt: ApiGatewayV2httpRequestContextAuthorizerJwtDescription,
+pub struct ApiGatewayV2httpRequestContextAuthorizerDescription<T1 = Value>
+where
+    T1: DeserializeOwned,
+    T1: Serialize,
+{
+    pub jwt: Option<ApiGatewayV2httpRequestContextAuthorizerJwtDescription>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(bound = "")]
+    pub lambda: HashMap<String, T1>,
+    pub iam: Option<ApiGatewayV2httpRequestContextAuthorizerIamDescription>,
 }
 
 /// `ApiGatewayV2httpRequestContextAuthorizerJwtDescription` contains JWT authorizer information for the request context.
@@ -225,7 +234,52 @@ pub struct ApiGatewayV2httpRequestContextAuthorizerJwtDescription {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub claims: HashMap<String, String>,
-    pub scopes: Vec<String>,
+    pub scopes: Option<Vec<String>>,
+}
+
+/// `ApiGatewayV2httpRequestContextAuthorizerIamDescription` contains IAM information for the request context.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ApiGatewayV2httpRequestContextAuthorizerIamDescription {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "accessKey")]
+    pub access_key: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "accountId")]
+    pub account_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "callerId")]
+    pub caller_id: Option<String>,
+    #[serde(rename = "cognitoIdentity")]
+    pub cognito_identity: Option<ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "principalOrgId")]
+    pub principal_org_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "userArn")]
+    pub user_arn: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "userId")]
+    pub user_id: Option<String>,
+}
+
+/// `ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity` contains Cognito identity information for the request context.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity {
+    pub amr: Vec<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "identityId")]
+    pub identity_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "identityPoolId")]
+    pub identity_pool_id: Option<String>,
 }
 
 /// `ApiGatewayV2httpRequestContextHttpDescription` contains HTTP information for the request context.

--- a/aws_lambda_events/src/generated/codebuild.rs
+++ b/aws_lambda_events/src/generated/codebuild.rs
@@ -66,7 +66,7 @@ pub struct CodeBuildEventDetail {
     #[serde(rename = "additional-information")]
     pub additional_information: CodeBuildEventAdditionalInformation,
     #[serde(rename = "current-phase")]
-    pub current_phase: CodeBuildPhaseStatus,
+    pub current_phase: CodeBuildPhaseType,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "current-phase-context")]
@@ -77,7 +77,7 @@ pub struct CodeBuildEventDetail {
     #[serde(rename = "completed-phase-status")]
     pub completed_phase_status: CodeBuildPhaseStatus,
     #[serde(rename = "completed-phase")]
-    pub completed_phase: CodeBuildPhaseStatus,
+    pub completed_phase: CodeBuildPhaseType,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "completed-phase-context")]
@@ -90,7 +90,7 @@ pub struct CodeBuildEventDetail {
     pub completed_phase_end: CodeBuildTime,
 }
 
-/// `CodeBuildEventAdditionalInformation` represents additional informations to the code build event
+/// `CodeBuildEventAdditionalInformation` represents additional information to the code build event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct CodeBuildEventAdditionalInformation {
     pub artifact: CodeBuildArtifact,

--- a/aws_lambda_events/src/generated/fixtures/example-kafka-event.json
+++ b/aws_lambda_events/src/generated/fixtures/example-kafka-event.json
@@ -1,0 +1,18 @@
+{
+    "eventSource": "aws:kafka",
+    "eventSourceArn": "arn:aws:kafka:us-west-2:012345678901:cluster/ExampleMSKCluster/e9f754c6-d29a-4430-a7db-958a19fd2c54-4",
+    "records": {
+      "AWSKafkaTopic-0": [
+        {
+          "topic": "AWSKafkaTopic",
+          "partition": 0,
+          "offset": 0,
+          "timestamp": 1595035749700,
+          "timestampType": "CREATE_TIME",
+          "key": "OGQ1NTk2YjQtMTgxMy00MjM4LWIyNGItNmRhZDhlM2QxYzBj",
+          "value": "OGQ1NTk2YjQtMTgxMy00MjM4LWIyNGItNmRhZDhlM2QxYzBj"
+        }
+      ]
+    }
+  }
+

--- a/aws_lambda_events/src/generated/kafka.rs
+++ b/aws_lambda_events/src/generated/kafka.rs
@@ -1,0 +1,50 @@
+use super::super::encodings::MillisecondTimestamp;
+use crate::custom_serde::*;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct KafkaEvent {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "eventSource")]
+    pub event_source: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "eventSourceArn")]
+    pub event_source_arn: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    pub records: HashMap<String, Vec<KafkaRecord>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct KafkaRecord {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub topic: Option<String>,
+    pub partition: i64,
+    pub offset: i64,
+    pub timestamp: MillisecondTimestamp,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "timestampType")]
+    pub timestamp_type: Option<String>,
+    pub key: Option<String>,
+    pub value: Option<String>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    extern crate serde_json;
+
+    #[test]
+    fn example_event() {
+        let data = include_bytes!("fixtures/example-kafka-event.json");
+        let parsed: KafkaEvent = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: KafkaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+}

--- a/aws_lambda_events/src/generated/mod.rs
+++ b/aws_lambda_events/src/generated/mod.rs
@@ -30,6 +30,8 @@ pub mod connect;
 pub mod firehose;
 /// AWS Lambda event definitions for iot_button.
 pub mod iot_button;
+/// AWS Lambda event definitions for kafka.
+pub mod kafka;
 /// AWS Lambda event definitions for kinesis.
 pub mod kinesis;
 /// AWS Lambda event definitions for kinesis_analytics.

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -80,6 +80,136 @@ where
     pub subject: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchAlarmSnsPayload {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "AlarmName")]
+    pub alarm_name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "AlarmDescription")]
+    pub alarm_description: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "AWSAccountId")]
+    pub aws_account_id: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "NewStateValue")]
+    pub new_state_value: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "NewStateReason")]
+    pub new_state_reason: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "StateChangeTime")]
+    pub state_change_time: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "Region")]
+    pub region: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "AlarmArn")]
+    pub alarm_arn: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "OldStateValue")]
+    pub old_state_value: Option<String>,
+    #[serde(rename = "Trigger")]
+    pub trigger: CloudWatchAlarmTrigger,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchAlarmTrigger {
+    #[serde(rename = "Period")]
+    pub period: i64,
+    #[serde(rename = "EvaluationPeriods")]
+    pub evaluation_periods: i64,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "ComparisonOperator")]
+    pub comparison_operator: Option<String>,
+    #[serde(rename = "Threshold")]
+    pub threshold: f64,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "TreatMissingData")]
+    pub treat_missing_data: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "EvaluateLowSampleCountPercentile")]
+    pub evaluate_low_sample_count_percentile: Option<String>,
+    #[serde(rename = "Metrics")]
+    pub metrics: Option<Vec<CloudWatchMetricDataQuery>>,
+    #[serde(rename = "MetricName")]
+    pub metric_name: Option<String>,
+    #[serde(rename = "Namespace")]
+    pub namespace: Option<String>,
+    #[serde(rename = "StatisticType")]
+    pub statistic_type: Option<String>,
+    #[serde(rename = "Statistic")]
+    pub statistic: Option<String>,
+    #[serde(rename = "Unit")]
+    pub unit: Option<String>,
+    #[serde(rename = "Dimensions")]
+    pub dimensions: Option<Vec<CloudWatchDimension>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchMetricDataQuery {
+    #[serde(rename = "Expression")]
+    pub expression: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "Id")]
+    pub id: Option<String>,
+    #[serde(rename = "Label")]
+    pub label: Option<String>,
+    #[serde(rename = "MetricStat")]
+    pub metric_stat: Option<CloudWatchMetricStat>,
+    #[serde(rename = "Period")]
+    pub period: Option<i64>,
+    #[serde(rename = "ReturnData")]
+    pub return_data: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchMetricStat {
+    #[serde(rename = "Metric")]
+    pub metric: CloudWatchMetric,
+    #[serde(rename = "Period")]
+    pub period: i64,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    #[serde(rename = "Stat")]
+    pub stat: Option<String>,
+    #[serde(rename = "Unit")]
+    pub unit: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchMetric {
+    #[serde(rename = "Dimensions")]
+    pub dimensions: Option<Vec<CloudWatchDimension>>,
+    #[serde(rename = "MetricName")]
+    pub metric_name: Option<String>,
+    #[serde(rename = "Namespace")]
+    pub namespace: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CloudWatchDimension {
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This is the result of me running the codegen locally with the latest `aws-lambda-go` definitions and checking the diff in.

In particular, I'm interested in this solving: https://github.com/LegNeato/aws-lambda-events/issues/25, but there are many more changes included.