### PR TITLE
Make bounded Go interfaces optional.

### DIFF
--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -461,7 +461,7 @@ where
     #[serde(rename = "resourcePath")]
     pub resource_path: Option<String>,
     #[serde(bound = "")]
-    pub authorizer: T1,
+    pub authorizer: Option<T1>,
     #[serde(with = "http_method")]
     #[serde(rename = "httpMethod")]
     pub http_method: Method,
@@ -501,7 +501,7 @@ where
     pub message_direction: Option<String>,
     #[serde(bound = "")]
     #[serde(rename = "messageId")]
-    pub message_id: T2,
+    pub message_id: Option<T2>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "requestTime")]

--- a/aws_lambda_events/src/generated/appsync.rs
+++ b/aws_lambda_events/src/generated/appsync.rs
@@ -16,7 +16,7 @@ where
     pub version: Option<String>,
     pub operation: AppSyncOperation,
     #[serde(bound = "")]
-    pub payload: T1,
+    pub payload: Option<T1>,
 }
 
 /// `AppSyncIamIdentity` contains information about the caller authed via IAM.

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -35,5 +35,5 @@ where
     pub region: Option<String>,
     pub resources: Vec<String>,
     #[serde(bound = "")]
-    pub detail: T1,
+    pub detail: Option<T1>,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -21,7 +21,7 @@ where T1: DeserializeOwned,
     pub timestamp: DateTime<Utc>,
     #[serde(bound="")]
     #[serde(rename = "rawJson")]
-    pub raw: T1,
+    pub raw: Option<T1>,
     pub destination: Vec<String>,
     pub headers: Vec<SimpleEmailHeader>,
     #[serde(rename = "headersTruncated")]

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/expected.txt
@@ -1,0 +1,12 @@
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct InterfaceMessage<T1=Value>
+where T1: DeserializeOwned,
+      T1: Serialize,
+{
+    #[serde(bound="")]
+    pub optional: Option<T1>,
+}

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/input.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/input.txt
@@ -1,0 +1,3 @@
+type InterfaceMessage struct {
+	Optional interface{} `json:"optional"`
+}


### PR DESCRIPTION
`interface{}` types can be null, and Lambda sends null objects for those in some cases, like websocket requests. This makes the translated objects optional, so the events are still parsed correctly.

Fixes #27

When this is merged, #26 can be closed since this is a general implementation of that.

Signed-off-by: David Calavera <david.calavera@gmail.com>