### PR TITLE
Make the http method in the Websocket request struct optional.

### DIFF
--- a/aws_lambda_events/src/generated/README.md
+++ b/aws_lambda_events/src/generated/README.md
@@ -3,4 +3,4 @@
 These types are automatically generated from the
 [official Go SDK](https://github.com/aws/aws-lambda-go/tree/master/events).
 
-Generated from commit [b3dd246b7d83fd62856549646711e5328075c69a](https://github.com/aws/aws-lambda-go/commit/b3dd246b7d83fd62856549646711e5328075c69a).
+Generated from commit [a8e138ffcbc1fffe8b5a615dc9d8276b844d670a](https://github.com/aws/aws-lambda-go/commit/a8e138ffcbc1fffe8b5a615dc9d8276b844d670a).

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -392,9 +392,11 @@ pub struct ApiGatewayWebsocketProxyRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
-    #[serde(with = "http_method")]
+    #[serde(deserialize_with = "http_method::deserialize_optional")]
+    #[serde(serialize_with = "http_method::serialize_optional")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "httpMethod")]
-    pub http_method: Method,
+    pub http_method: Option<Method>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize")]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -265,6 +265,10 @@ pub struct CognitoEventUserPoolsMigrateUserRequest {
     pub password: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
+    #[serde(rename = "validationData")]
+    pub validation_data: HashMap<String, String>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
     #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }

--- a/aws_lambda_events/src/generated/lex.rs
+++ b/aws_lambda_events/src/generated/lex.rs
@@ -22,6 +22,8 @@ pub struct LexEvent {
     pub output_dialog_mode: Option<String>,
     #[serde(rename = "currentIntent")]
     pub current_intent: Option<LexCurrentIntent>,
+    #[serde(rename = "alternativeIntents")]
+    pub alternative_intents: Option<Vec<LexAlternativeIntents>>,
     #[serde(rename = "dialogAction")]
     pub dialog_action: Option<LexDialogAction>,
 }
@@ -36,6 +38,22 @@ pub struct LexBot {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct LexCurrentIntent {
     pub name: Option<String>,
+    #[serde(rename = "nluIntentConfidenceScore")]
+    pub nlu_intent_confidence_score: Option<f64>,
+    pub slots: Option<Slots>,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    #[serde(rename = "slotDetails")]
+    pub slot_details: HashMap<String, SlotDetail>,
+    #[serde(rename = "confirmationStatus")]
+    pub confirmation_status: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct LexAlternativeIntents {
+    pub name: Option<String>,
+    #[serde(rename = "nluIntentConfidenceScore")]
+    pub nlu_intent_confidence_score: Option<f64>,
     pub slots: Option<Slots>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -731,21 +731,9 @@ fn translate_go_type_to_rust_type<'a>(
             libraries.insert("crate::custom_serde::*".to_string());
             libraries.insert("http::Method".to_string());
 
-            // Temporary patch to fix https://github.com/LegNeato/aws-lambda-events/issues/33
-            // It will allow the code to be correct even after the Go bindings make the
-            // http method optional.
-            let mut value = "Method";
             let mut annotations = vec!["#[serde(with = \"http_method\")]".to_string()];
-
             if let Some(def) = member_def {
                 if def.struct_name == "ApiGatewayWebsocketProxyRequest" {
-                    // The Go bindings don't mark this field as an optional, but it is.
-                    // When the Go bindings fix that problem, the following check will
-                    // prevent us from creating an Option<Option<Method>>, which would
-                    // be wrong.
-                    if !def.omit_empty {
-                        value = "Option<Method>";
-                    }
                     annotations = vec![
                         "#[serde(deserialize_with = \"http_method::deserialize_optional\")]"
                             .to_string(),
@@ -757,7 +745,7 @@ fn translate_go_type_to_rust_type<'a>(
             }
 
             RustType {
-                value: value.into(),
+                value: "Method".into(),
                 annotations,
                 libraries,
                 generics: vec![],

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -156,6 +156,7 @@ struct FieldDef {
 struct StructureFieldDef<'a> {
     struct_name: &'a str,
     member_name: &'a str,
+    omit_empty: bool,
 }
 
 fn parse_comment(c: &str) -> String {
@@ -290,6 +291,7 @@ fn parse_struct(pairs: Pairs<'_, Rule>) -> Result<(codegen::Struct, HashSet<Stri
         let member_def = StructureFieldDef {
             struct_name: &camel_cased_struct_name,
             member_name: &member_name,
+            omit_empty: f.omit_empty,
         };
 
         let mut rust_data =
@@ -729,11 +731,36 @@ fn translate_go_type_to_rust_type<'a>(
             libraries.insert("crate::custom_serde::*".to_string());
             libraries.insert("http::Method".to_string());
 
+            // Temporary patch to fix https://github.com/LegNeato/aws-lambda-events/issues/33
+            // It will allow the code to be correct even after the Go bindings make the
+            // http method optional.
+            let mut value = "Method";
+            let mut annotations = vec!["#[serde(with = \"http_method\")]".to_string()];
+
+            if let Some(def) = member_def {
+                if def.struct_name == "ApiGatewayWebsocketProxyRequest" {
+                    // The Go bindings don't mark this field as an optional, but it is.
+                    // When the Go bindings fix that problem, the following check will
+                    // prevent us from creating an Option<Option<Method>>, which would
+                    // be wrong.
+                    if !def.omit_empty {
+                        value = "Option<Method>";
+                    }
+                    annotations = vec![
+                        "#[serde(deserialize_with = \"http_method::deserialize_optional\")]"
+                            .to_string(),
+                        "#[serde(serialize_with = \"http_method::serialize_optional\")]"
+                            .to_string(),
+                        "#[serde(skip_serializing_if = \"Option::is_none\")]".to_string(),
+                    ];
+                }
+            }
+
             RustType {
-                value: "Method".into(),
-                annotations: vec!["#[serde(with = \"http_method\")]".to_string()],
-                generics: vec![],
+                value: value.into(),
+                annotations,
                 libraries,
+                generics: vec![],
             }
         }
         GoType::StringType if is_http_body(member_def) => {
@@ -960,15 +987,14 @@ fn is_http_multivalue_headers<'a>(def: Option<&'a StructureFieldDef>) -> bool {
 
 fn is_http_method<'a>(def: Option<&'a StructureFieldDef>) -> bool {
     match def {
-        Some(&StructureFieldDef { member_name, .. }) if member_name == "http_method" => true,
         Some(&StructureFieldDef {
             member_name,
             struct_name,
             ..
-        }) if struct_name == "ApiGatewayV2httpRequestContextHttpDescription"
-            && member_name == "method" =>
-        {
-            true
+        }) => {
+            member_name == "http_method"
+                || (struct_name == "ApiGatewayV2httpRequestContextHttpDescription"
+                    && member_name == "method")
         }
         _ => false,
     }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
@@ -24,3 +24,12 @@ pub struct ApiGatewayProxyResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Body>,
 }
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ApiGatewayWebsocketProxyRequest {
+    #[serde(deserialize_with = "http_method::deserialize_optional")]
+    #[serde(serialize_with = "http_method::serialize_optional")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "httpMethod")]
+    pub http_method: Option<Method>,
+}

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/input.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/input.txt
@@ -10,5 +10,5 @@ type ApiGatewayProxyResponse struct {
 }
 
 type ApiGatewayWebsocketProxyRequest struct {
-	HttpMethod string `json:"httpMethod"`
+	HttpMethod string `json:"httpMethod,omitempty"`
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/input.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/input.txt
@@ -8,3 +8,7 @@ type HttpMessage struct {
 type ApiGatewayProxyResponse struct {
 	Body string `json:"body"`
 }
+
+type ApiGatewayWebsocketProxyRequest struct {
+	HttpMethod string `json:"httpMethod"`
+}


### PR DESCRIPTION
@LegNeato I made some adjustments to properly serialize and deserialize the optional method. The code should still work correctly after the Go bindings are fixed, but we can also retouch this patch then.

Fixes #33 

Signed-off-by: David Calavera <david.calavera@gmail.com>