### PR TITLE
Add default to http_serde::header_map::deserialize

### DIFF
--- a/aws_lambda_events/src/custom_serde.rs
+++ b/aws_lambda_events/src/custom_serde.rs
@@ -518,4 +518,21 @@ mod test {
         let encoded = serde_json::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":36}"#));
     }
+
+    #[test]
+    fn test_deserialize_missing_http_headers() {
+        #[derive(Deserialize)]
+        struct Test {
+            #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
+            pub headers: HeaderMap,
+        }
+        let data = json!({
+            "not_headers": {}
+        });
+
+        let expected = HeaderMap::new();
+
+        let decoded: Test = serde_json::from_value(data).unwrap();
+        assert_eq!(expected, decoded.headers);
+    }
 }

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -817,7 +817,7 @@ fn translate_go_type_to_rust_type<'a>(
             libraries.insert("http::HeaderMap".to_string());
 
             let mut annotations = vec![
-                "#[serde(deserialize_with = \"http_serde::header_map::deserialize\")]".to_string(),
+                "#[serde(deserialize_with = \"http_serde::header_map::deserialize\", default)]".to_string(),
             ];
             let ser = if is_http_multivalue_headers(member_def) {
                 "#[serde(serialize_with = \"serialize_multi_value_headers\")]"

--- a/aws_lambda_events_codegen/go_to_rust/src/lib.rs
+++ b/aws_lambda_events_codegen/go_to_rust/src/lib.rs
@@ -817,7 +817,8 @@ fn translate_go_type_to_rust_type<'a>(
             libraries.insert("http::HeaderMap".to_string());
 
             let mut annotations = vec![
-                "#[serde(deserialize_with = \"http_serde::header_map::deserialize\", default)]".to_string(),
+                "#[serde(deserialize_with = \"http_serde::header_map::deserialize\", default)]"
+                    .to_string(),
             ];
             let ser = if is_http_multivalue_headers(member_def) {
                 "#[serde(serialize_with = \"serialize_multi_value_headers\")]"

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
@@ -7,10 +7,10 @@ pub struct HttpMessage {
     #[serde(with = "http_method")]
     #[serde(rename = "httpMethod")]
     pub http_method: Method,
-    #[serde(deserialize_with = "http_serde::header_map::deserialize")]
+    #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
-    #[serde(deserialize_with = "http_serde::header_map::deserialize")]
+    #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,


### PR DESCRIPTION
The Go SDK typically has `omitEmpty` for Rust's `http::HeaderMap` entries, and services like ALB omit them when they're not present. However, without a `default` parameter to the `#[serde()]` annotation, deserialization fails when they're missing instead of the desired behavior of producing an empty `HeaderMap`.

This changes `#[serde(deserialize_with = "http_serde::header_map::deserialize")]` annotations to `#[serde(deserialize_with = "http_serde::header_map::deserialize", default)]` so we get the desired behavior. A test is also added (in `aws_lambda_events/src/custom_serde.rs` -- feel free to suggest a better place if there is one) to verify the correctness of this change.