### PR TITLE
Remove override entirely.

### DIFF
--- a/aws_lambda_events_codegen/src/main.rs
+++ b/aws_lambda_events_codegen/src/main.rs
@@ -140,7 +140,6 @@ fn find_example_events(
     scope: &codegen::Scope,
 ) -> Vec<ExampleEvent> {
     let mut name_with_quirks = match service_name {
-        "codepipeline_job" => "codepipeline-job-event.json".to_string(),
         "firehose" => "kinesis-firehose-event.json".to_string(),
         service_name => format!("{}-event.json", service_name),
     };


### PR DESCRIPTION
We don't need this because it now matches our standard location logic