### PR TITLE
Serialize all struct fields as camelCase by default

### DIFF
--- a/aws_lambda_events/src/generated/activemq.rs
+++ b/aws_lambda_events/src/generated/activemq.rs
@@ -1,19 +1,19 @@
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ActiveMqEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSourceArn")]
     pub event_source_arn: Option<String>,
     pub messages: Vec<ActiveMqMessage>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ActiveMqMessage {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -21,10 +21,8 @@ pub struct ActiveMqMessage {
     pub message_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageType")]
     pub message_type: Option<String>,
     pub timestamp: i64,
-    #[serde(rename = "deliveryMode")]
     pub delivery_mode: i64,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -32,30 +30,26 @@ pub struct ActiveMqMessage {
     pub correlation_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "replyTo")]
     pub reply_to: Option<String>,
     pub destination: ActiveMqDestination,
     pub redelivered: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     pub expiration: i64,
     pub priority: i64,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub data: Option<String>,
-    #[serde(rename = "brokerInTime")]
     pub broker_in_time: i64,
-    #[serde(rename = "brokerOutTime")]
     pub broker_out_time: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ActiveMqDestination {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "physicalName")]
     pub physical_name: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/alb.rs
+++ b/aws_lambda_events/src/generated/alb.rs
@@ -5,70 +5,63 @@ use std::collections::HashMap;
 
 /// `AlbTargetGroupRequest` contains data originating from the ALB Lambda target group integration
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AlbTargetGroupRequest {
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
     pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
-    #[serde(rename = "requestContext")]
     pub request_context: AlbTargetGroupRequestContext,
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: bool,
     pub body: Option<String>,
 }
 
 /// `AlbTargetGroupRequestContext` contains the information to identify the load balancer invoking the lambda
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AlbTargetGroupRequestContext {
     pub elb: ElbContext,
 }
 
 /// `ElbContext` contains the information to identify the ARN invoking the lambda
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ElbContext {
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "targetGroupArn")]
     pub target_group_arn: Option<String>,
 }
 
 /// `AlbTargetGroupResponse` configures the response to be returned by the ALB Lambda target group for the request
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AlbTargetGroupResponse {
-    #[serde(rename = "statusCode")]
     pub status_code: i64,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "statusDescription")]
     pub status_description: Option<String>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Body>,
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: bool,
 }
 

--- a/aws_lambda_events/src/generated/apigw.rs
+++ b/aws_lambda_events/src/generated/apigw.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 /// `ApiGatewayProxyRequest` contains data coming from the API Gateway proxy
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayProxyRequest {
     /// The resource path defined in API Gateway
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -18,64 +19,55 @@ pub struct ApiGatewayProxyRequest {
     #[serde(default)]
     pub path: Option<String>,
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
     pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "pathParameters")]
     pub path_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "stageVariables")]
     pub stage_variables: HashMap<String, String>,
     #[serde(default)]
-    #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayProxyRequestContext,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: Option<bool>,
 }
 
 /// `ApiGatewayProxyResponse` configures the response to be returned by API Gateway for the request
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayProxyResponse {
-    #[serde(rename = "statusCode")]
     pub status_code: i64,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Body>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: Option<bool>,
 }
 
 /// `ApiGatewayProxyRequestContext` contains the information to identify the AWS account and resources invoking the
 /// Lambda function. It also includes Cognito identity information for the caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayProxyRequestContext<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -83,28 +75,22 @@ where
 {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourceId")]
     pub resource_id: Option<String>,
-    #[serde(rename = "operationName")]
     pub operation_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "domainName")]
     pub domain_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "domainPrefix")]
     pub domain_prefix: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -113,20 +99,16 @@ where
     pub identity: ApiGatewayRequestIdentity,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourcePath")]
     pub resource_path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(bound = "")]
     pub authorizer: HashMap<String, T1>,
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestTime")]
     pub request_time: Option<String>,
-    #[serde(rename = "requestTimeEpoch")]
     pub request_time_epoch: i64,
     /// The API Gateway rest API Id
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -137,21 +119,19 @@ where
 
 /// `ApiGatewayV2httpRequest` contains data coming from the new HTTP API Gateway
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "routeKey")]
     pub route_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "rawPath")]
     pub raw_path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "rawQueryString")]
     pub raw_query_string: Option<String>,
     pub cookies: Option<Vec<String>>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
@@ -159,40 +139,33 @@ pub struct ApiGatewayV2httpRequest {
     pub headers: HeaderMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "pathParameters")]
     pub path_parameters: HashMap<String, String>,
-    #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayV2httpRequestContext,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "stageVariables")]
     pub stage_variables: HashMap<String, String>,
     pub body: Option<String>,
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: bool,
 }
 
 /// `ApiGatewayV2httpRequestContext` contains the information to identify the AWS account and resources invoking the Lambda function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "routeKey")]
     pub route_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     pub authorizer: Option<ApiGatewayV2httpRequestContextAuthorizerDescription>,
     /// The API Gateway HTTP API Id
@@ -202,16 +175,13 @@ pub struct ApiGatewayV2httpRequestContext {
     pub apiid: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "domainName")]
     pub domain_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "domainPrefix")]
     pub domain_prefix: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub time: Option<String>,
-    #[serde(rename = "timeEpoch")]
     pub time_epoch: i64,
     pub http: ApiGatewayV2httpRequestContextHttpDescription,
     #[serde(default)]
@@ -220,6 +190,7 @@ pub struct ApiGatewayV2httpRequestContext {
 
 /// `ApiGatewayV2httpRequestContextAuthorizerDescription` contains authorizer information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthorizerDescription<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -235,6 +206,7 @@ where
 
 /// `ApiGatewayV2httpRequestContextAuthorizerJwtDescription` contains JWT authorizer information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthorizerJwtDescription {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -244,51 +216,45 @@ pub struct ApiGatewayV2httpRequestContextAuthorizerJwtDescription {
 
 /// `ApiGatewayV2httpRequestContextAuthorizerIamDescription` contains IAM information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthorizerIamDescription {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accessKey")]
     pub access_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "callerId")]
     pub caller_id: Option<String>,
-    #[serde(rename = "cognitoIdentity")]
     pub cognito_identity: Option<ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "principalOrgId")]
     pub principal_org_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userArn")]
     pub user_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userId")]
     pub user_id: Option<String>,
 }
 
 /// `ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity` contains Cognito identity information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthorizerCognitoIdentity {
     pub amr: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "identityId")]
     pub identity_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "identityPoolId")]
     pub identity_pool_id: Option<String>,
 }
 
 /// `ApiGatewayV2httpRequestContextHttpDescription` contains HTTP information for the request context.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextHttpDescription {
     #[serde(with = "http_method")]
     pub method: Method,
@@ -300,84 +266,70 @@ pub struct ApiGatewayV2httpRequestContextHttpDescription {
     pub protocol: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sourceIp")]
     pub source_ip: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userAgent")]
     pub user_agent: Option<String>,
 }
 
 /// `ApiGatewayV2httpResponse` configures the response to be returned by API Gateway V2 for the request
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpResponse {
-    #[serde(rename = "statusCode")]
     pub status_code: i64,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Body>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: Option<bool>,
     pub cookies: Vec<String>,
 }
 
 /// `ApiGatewayRequestIdentity` contains identity information for the request caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoIdentityPoolId")]
     pub cognito_identity_pool_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoIdentityId")]
     pub cognito_identity_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub caller: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "apiKeyId")]
     pub api_key_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accessKey")]
     pub access_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sourceIp")]
     pub source_ip: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoAuthenticationType")]
     pub cognito_authentication_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoAuthenticationProvider")]
     pub cognito_authentication_provider: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userArn")]
     pub user_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userAgent")]
     pub user_agent: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -386,6 +338,7 @@ pub struct ApiGatewayRequestIdentity {
 
 /// `ApiGatewayWebsocketProxyRequest` contains data coming from the API Gateway proxy
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayWebsocketProxyRequest {
     /// The resource path defined in API Gateway
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -398,38 +351,30 @@ pub struct ApiGatewayWebsocketProxyRequest {
     #[serde(deserialize_with = "http_method::deserialize_optional")]
     #[serde(serialize_with = "http_method::serialize_optional")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Option<Method>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
     pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "pathParameters")]
     pub path_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "stageVariables")]
     pub stage_variables: HashMap<String, String>,
-    #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayWebsocketProxyRequestContext,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: Option<bool>,
 }
 
@@ -437,6 +382,7 @@ pub struct ApiGatewayWebsocketProxyRequest {
 /// the AWS account and resources invoking the Lambda function. It also includes
 /// Cognito identity information for the caller.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayWebsocketProxyRequestContext<T1 = Value, T2 = Value>
 where
     T1: DeserializeOwned,
@@ -446,78 +392,62 @@ where
 {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourceId")]
     pub resource_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     #[serde(default)]
     pub identity: ApiGatewayRequestIdentity,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourcePath")]
     pub resource_path: Option<String>,
     #[serde(bound = "")]
     pub authorizer: Option<T1>,
     #[serde(deserialize_with = "http_method::deserialize_optional")]
     #[serde(serialize_with = "http_method::serialize_optional")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Option<Method>,
     /// The API Gateway rest API Id
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     #[serde(rename = "apiId")]
     pub apiid: Option<String>,
-    #[serde(rename = "connectedAt")]
     pub connected_at: i64,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "connectionId")]
     pub connection_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "domainName")]
     pub domain_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub error: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventType")]
     pub event_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "extendedRequestId")]
     pub extended_request_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "integrationLatency")]
     pub integration_latency: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageDirection")]
     pub message_direction: Option<String>,
     #[serde(bound = "")]
-    #[serde(rename = "messageId")]
     pub message_id: Option<T2>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestTime")]
     pub request_time: Option<String>,
-    #[serde(rename = "requestTimeEpoch")]
     pub request_time_epoch: i64,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "routeKey")]
     pub route_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -526,25 +456,23 @@ where
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller including certificate information if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sourceIp")]
     pub source_ip: Option<String>,
-    #[serde(rename = "clientCert")]
     pub client_cert: ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert,
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert` contains certificate information for the request caller if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clientCertPem")]
     pub client_cert_pem: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -552,7 +480,6 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert {
     pub issuer_dn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "serialNumber")]
     pub serial_number: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -563,30 +490,29 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert {
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCertValidity` contains certificate validity information for the request caller if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCertValidity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "notAfter")]
     pub not_after: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "notBefore")]
     pub not_before: Option<String>,
 }
 
 /// `ApiGatewayV2httpRequestContextAuthentication` contains authentication context information for the request caller including client certificate information if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthentication {
-    #[serde(rename = "clientCert")]
     pub client_cert: ApiGatewayV2httpRequestContextAuthenticationClientCert,
 }
 
 /// `ApiGatewayV2httpRequestContextAuthenticationClientCert` contains client certificate information for the request caller if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthenticationClientCert {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clientCertPem")]
     pub client_cert_pem: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -594,7 +520,6 @@ pub struct ApiGatewayV2httpRequestContextAuthenticationClientCert {
     pub issuer_dn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "serialNumber")]
     pub serial_number: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -605,60 +530,52 @@ pub struct ApiGatewayV2httpRequestContextAuthenticationClientCert {
 
 /// `ApiGatewayV2httpRequestContextAuthenticationClientCertValidity` contains client certificate validity information for the request caller if using mTLS.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthenticationClientCertValidity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "notAfter")]
     pub not_after: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "notBefore")]
     pub not_before: Option<String>,
 }
 
 /// `ApiGatewayCustomAuthorizerContext` represents the expected format of an API Gateway custom authorizer response.
 /// Deprecated. Code should be updated to use the Authorizer map from APIGatewayRequestIdentity. Ex: Authorizer["principalId"]
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerContext {
-    #[serde(rename = "principalId")]
     pub principal_id: Option<String>,
-    #[serde(rename = "stringKey")]
     pub string_key: Option<String>,
-    #[serde(rename = "numKey")]
     pub num_key: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "boolKey")]
     pub bool_key: Option<bool>,
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestContext` represents the expected format of an API Gateway custom authorizer response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourceId")]
     pub resource_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub stage: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     pub identity: ApiGatewayCustomAuthorizerRequestTypeRequestIdentity,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resourcePath")]
     pub resource_path: Option<String>,
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -668,33 +585,30 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
 
 /// `ApiGatewayCustomAuthorizerRequest` contains data coming in to a custom API Gateway authorizer function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "authorizationToken")]
     pub authorization_token: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "methodArn")]
     pub method_arn: Option<String>,
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequest` contains data coming in to a custom API Gateway authorizer function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "methodArn")]
     pub method_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -703,37 +617,31 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(default)]
     pub path: Option<String>,
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "queryStringParameters")]
     pub query_string_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "multiValueQueryStringParameters")]
     pub multi_value_query_string_parameters: HashMap<String, Vec<String>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "pathParameters")]
     pub path_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "stageVariables")]
     pub stage_variables: HashMap<String, String>,
-    #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayCustomAuthorizerRequestTypeRequestContext,
 }
 
 /// `ApiGatewayCustomAuthorizerResponse` represents the expected format of an API Gateway authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerResponse<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -741,26 +649,23 @@ where
 {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "principalId")]
     pub principal_id: Option<String>,
-    #[serde(rename = "policyDocument")]
     pub policy_document: ApiGatewayCustomAuthorizerPolicy,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(bound = "")]
     pub context: HashMap<String, T1>,
-    #[serde(rename = "usageIdentifierKey")]
     pub usage_identifier_key: Option<String>,
 }
 
 /// `ApiGatewayV2CustomAuthorizerSimpleResponse` represents the simple format of an API Gateway V2 authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2CustomAuthorizerSimpleResponse<T1 = Value>
 where
     T1: DeserializeOwned,
     T1: Serialize,
 {
-    #[serde(rename = "isAuthorized")]
     pub is_authorized: bool,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -770,6 +675,7 @@ where
 
 /// `ApiGatewayCustomAuthorizerPolicy` represents an IAM policy
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerPolicy {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -781,6 +687,7 @@ pub struct ApiGatewayCustomAuthorizerPolicy {
 
 /// `IamPolicyStatement` represents one statement from IAM policy with action, effect and resource
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IamPolicyStatement {
     #[serde(rename = "Action")]
     pub action: Vec<String>,

--- a/aws_lambda_events/src/generated/appsync.rs
+++ b/aws_lambda_events/src/generated/appsync.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 /// `AppSyncResolverTemplate` represents the requests from AppSync to Lambda
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncResolverTemplate<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -21,32 +22,29 @@ where
 
 /// `AppSyncIamIdentity` contains information about the caller authed via IAM.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncIamIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoIdentityPoolId")]
     pub cognito_identity_pool_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "cognitoIdentityId")]
     pub cognito_identity_id: Option<String>,
-    #[serde(rename = "sourceIp")]
     pub source_ip: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub username: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userArn")]
     pub user_arn: Option<String>,
 }
 
 /// `AppSyncCognitoIdentity` contains information about the caller authed via Cognito.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncCognitoIdentity<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -65,11 +63,9 @@ where
     #[serde(default)]
     #[serde(bound = "")]
     pub claims: HashMap<String, T1>,
-    #[serde(rename = "sourceIp")]
     pub source_ip: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "defaultAuthStrategy")]
     pub default_auth_strategy: Option<String>,
 }
 
@@ -77,18 +73,18 @@ pub type AppSyncOperation = String;
 
 /// `AppSyncLambdaAuthorizerRequest` contains an authorization request from AppSync.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncLambdaAuthorizerRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "authorizationToken")]
     pub authorization_token: Option<String>,
-    #[serde(rename = "requestContext")]
     pub request_context: AppSyncLambdaAuthorizerRequestContext,
 }
 
 /// `AppSyncLambdaAuthorizerRequestContext` contains the parameters of the AppSync invocation which triggered
 /// this authorization request.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncLambdaAuthorizerRequestContext<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -100,19 +96,15 @@ where
     pub apiid: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "requestId")]
     pub request_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "queryString")]
     pub query_string: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "operationName")]
     pub operation_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -122,20 +114,17 @@ where
 
 /// `AppSyncLambdaAuthorizerResponse` represents the expected format of an authorization response to AppSync.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSyncLambdaAuthorizerResponse<T1 = Value>
 where
     T1: DeserializeOwned,
     T1: Serialize,
 {
-    #[serde(rename = "isAuthorized")]
     pub is_authorized: bool,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(bound = "")]
-    #[serde(rename = "resolverContext")]
     pub resolver_context: HashMap<String, T1>,
-    #[serde(rename = "deniedFields")]
     pub denied_fields: Option<Vec<String>>,
-    #[serde(rename = "ttlOverride")]
     pub ttl_override: Option<i64>,
 }

--- a/aws_lambda_events/src/generated/autoscaling.rs
+++ b/aws_lambda_events/src/generated/autoscaling.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 /// `AutoScalingEvent` struct is used to parse the json for auto scaling event types //
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AutoScalingEvent<T1 = Value>
 where
     T1: DeserializeOwned,

--- a/aws_lambda_events/src/generated/chime_bot.rs
+++ b/aws_lambda_events/src/generated/chime_bot.rs
@@ -2,6 +2,7 @@ use crate::custom_serde::*;
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChimeBotEvent {
     #[serde(rename = "Sender")]
     pub sender: ChimeBotEventSender,
@@ -20,6 +21,7 @@ pub struct ChimeBotEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventSender {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -32,6 +34,7 @@ pub struct ChimeBotEventSender {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventDiscussion {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -44,6 +47,7 @@ pub struct ChimeBotEventDiscussion {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventInboundHttpsEndpoint {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/clientvpn.rs
+++ b/aws_lambda_events/src/generated/clientvpn.rs
@@ -1,6 +1,7 @@
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClientVpnConnectionHandlerRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -40,6 +41,7 @@ pub struct ClientVpnConnectionHandlerRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClientVpnConnectionHandlerResponse {
     pub allow: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events/src/generated/cloudwatch_events.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_events.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 /// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
 /// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchEvent<T1 = Value>
 where
     T1: DeserializeOwned,

--- a/aws_lambda_events/src/generated/cloudwatch_logs.rs
+++ b/aws_lambda_events/src/generated/cloudwatch_logs.rs
@@ -2,6 +2,7 @@ use crate::custom_serde::*;
 
 /// `CloudwatchLogsEvent` represents raw data from a cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudwatchLogsEvent {
     #[serde(rename = "awslogs")]
     pub aws_logs: CloudwatchLogsRawData,
@@ -10,6 +11,7 @@ pub struct CloudwatchLogsEvent {
 /// `CloudwatchLogsRawData` contains gzipped base64 json representing the bulk
 /// of a cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudwatchLogsRawData {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -18,30 +20,27 @@ pub struct CloudwatchLogsRawData {
 
 /// `CloudwatchLogsData` is an unmarshal'd, ungzip'd, cloudwatch logs event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudwatchLogsData {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub owner: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "logGroup")]
     pub log_group: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "logStream")]
     pub log_stream: Option<String>,
-    #[serde(rename = "subscriptionFilters")]
     pub subscription_filters: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageType")]
     pub message_type: Option<String>,
-    #[serde(rename = "logEvents")]
     pub log_events: Vec<CloudwatchLogsLogEvent>,
 }
 
 /// `CloudwatchLogsLogEvent` represents a log entry from cloudwatch logs
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudwatchLogsLogEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/code_commit.rs
+++ b/aws_lambda_events/src/generated/code_commit.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 
 /// `CodeCommitEvent` represents a CodeCommit event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeCommitEvent {
     #[serde(rename = "Records")]
     pub records: Vec<CodeCommitRecord>,
@@ -12,33 +13,27 @@ pub type CodeCommitEventTime = DateTime<Utc>;
 
 /// `CodeCommitRecord` represents a CodeCommit record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeCommitRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventId")]
     pub event_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventVersion")]
     pub event_version: Option<String>,
-    #[serde(rename = "eventTime")]
     pub event_time: CodeCommitEventTime,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventTriggerName")]
     pub event_trigger_name: Option<String>,
-    #[serde(rename = "eventPartNumber")]
     pub event_part_number: u64,
     #[serde(rename = "codecommit")]
     pub code_commit: CodeCommitCodeCommit,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventName")]
     pub event_name: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventTriggerConfigId")]
     pub event_trigger_config_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -50,33 +45,30 @@ pub struct CodeCommitRecord {
     pub user_identity_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "awsRegion")]
     pub aws_region: Option<String>,
-    #[serde(rename = "eventTotalParts")]
     pub event_total_parts: u64,
-    #[serde(rename = "customData")]
     pub custom_data: Option<String>,
 }
 
 /// `CodeCommitCodeCommit` represents a CodeCommit object in a record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeCommitCodeCommit {
     pub references: Vec<CodeCommitReference>,
 }
 
 /// `CodeCommitReference` represents a Reference object in a CodeCommit object
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeCommitReference {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub commit: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "ref")]
     pub ref_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<bool>,

--- a/aws_lambda_events/src/generated/codebuild.rs
+++ b/aws_lambda_events/src/generated/codebuild.rs
@@ -12,6 +12,7 @@ pub type CodeBuildPhaseType = String;
 /// `CodeBuildEvent` is documented at:
 /// https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html#sample-build-notifications-ref
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildEvent {
     /// AccountID is the id of the AWS account from which the event originated.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -52,6 +53,7 @@ pub struct CodeBuildEvent {
 
 /// `CodeBuildEventDetail` represents the all details related to the code build event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildEventDetail {
     #[serde(rename = "build-status")]
     pub build_status: CodeBuildPhaseStatus,
@@ -92,6 +94,7 @@ pub struct CodeBuildEventDetail {
 
 /// `CodeBuildEventAdditionalInformation` represents additional information to the code build event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildEventAdditionalInformation {
     pub artifact: CodeBuildArtifact,
     pub environment: CodeBuildEnvironment,
@@ -111,6 +114,7 @@ pub struct CodeBuildEventAdditionalInformation {
 
 /// `CodeBuildArtifact` represents the artifact provided to build
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildArtifact {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -127,6 +131,7 @@ pub struct CodeBuildArtifact {
 
 /// `CodeBuildEnvironment` represents the environment for a build
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildEnvironment {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -139,7 +144,6 @@ pub struct CodeBuildEnvironment {
     pub compute_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     #[serde(rename = "environment-variables")]
     pub environment_variables: Vec<CodeBuildEnvironmentVariable>,
@@ -147,6 +151,7 @@ pub struct CodeBuildEnvironment {
 
 /// `CodeBuildEnvironmentVariable` encapsulate environment variables for the code build
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildEnvironmentVariable {
     /// Name is the name of the environment variable.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -155,7 +160,6 @@ pub struct CodeBuildEnvironmentVariable {
     /// Type is PLAINTEXT or PARAMETER_STORE.
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     /// Value is the value of the environment variable.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -165,18 +169,19 @@ pub struct CodeBuildEnvironmentVariable {
 
 /// `CodeBuildSource` represent the code source will be build
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildSource {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub location: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
 }
 
 /// `CodeBuildLogs` gives the log details of a code build
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildLogs {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -194,6 +199,7 @@ pub struct CodeBuildLogs {
 
 /// `CodeBuildPhase` represents the phase of a build and its details
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeBuildPhase<T1 = Value>
 where
     T1: DeserializeOwned,

--- a/aws_lambda_events/src/generated/codedeploy.rs
+++ b/aws_lambda_events/src/generated/codedeploy.rs
@@ -6,6 +6,7 @@ pub type CodeDeployDeploymentState = String;
 /// `CodeDeployEvent` is documented at:
 /// https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#acd_event_types
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeDeployEvent {
     /// AccountID is the id of the AWS account from which the event originated.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -46,15 +47,14 @@ pub struct CodeDeployEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeDeployEventDetail {
     /// InstanceGroupID is the ID of the instance group.
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "instanceGroupId")]
     pub instance_group_id: Option<String>,
     /// InstanceID is the id of the instance. This field is non-empty only if
     /// the DetailType of the complete event is CodeDeployInstanceEventDetailType.
-    #[serde(rename = "instanceId")]
     pub instance_id: Option<String>,
     /// Region is the AWS region that the event originated from.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -67,13 +67,11 @@ pub struct CodeDeployEventDetail {
     /// DeploymentID is the id of the deployment.
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "deploymentId")]
     pub deployment_id: Option<String>,
     /// State is the new state of the deployment.
     pub state: CodeDeployDeploymentState,
     /// DeploymentGroup is the name of the deployment group.
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "deploymentGroup")]
     pub deployment_group: Option<String>,
 }

--- a/aws_lambda_events/src/generated/codepipeline_cloudwatch.rs
+++ b/aws_lambda_events/src/generated/codepipeline_cloudwatch.rs
@@ -10,6 +10,7 @@ pub type CodePipelineActionState = String;
 /// CodePipelineEvent is documented at:
 /// https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#codepipeline_event_type
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineCloudWatchEvent {
     /// Version is the version of the event's schema.
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -50,6 +51,7 @@ pub struct CodePipelineCloudWatchEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineEventDetail {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -70,11 +72,11 @@ pub struct CodePipelineEventDetail {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,
-    #[serde(rename = "type")]
     pub type_: CodePipelineEventDetailType,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineEventDetailType {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/codepipeline_job.rs
+++ b/aws_lambda_events/src/generated/codepipeline_job.rs
@@ -2,6 +2,7 @@ use crate::custom_serde::*;
 
 /// `CodePipelineJobEvent` contains data from an event sent from AWS CodePipeline
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineJobEvent {
     #[serde(rename = "CodePipeline.job")]
     pub code_pipeline_job: CodePipelineJob,
@@ -9,42 +10,41 @@ pub struct CodePipelineJobEvent {
 
 /// `CodePipelineJob` represents a job from an AWS CodePipeline event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineJob {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     pub data: CodePipelineData,
 }
 
 /// `CodePipelineData` represents a job from an AWS CodePipeline event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineData {
-    #[serde(rename = "actionConfiguration")]
     pub action_configuration: CodePipelineActionConfiguration,
-    #[serde(rename = "inputArtifacts")]
     pub input_artifacts: Vec<CodePipelineInputArtifact>,
     #[serde(rename = "outputArtifacts")]
     pub out_put_artifacts: Vec<CodePipelineOutputArtifact>,
-    #[serde(rename = "artifactCredentials")]
     pub artifact_credentials: CodePipelineArtifactCredentials,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "continuationToken")]
     pub continuation_token: Option<String>,
 }
 
 /// `CodePipelineActionConfiguration` represents an Action Configuration
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineActionConfiguration {
     pub configuration: CodePipelineConfiguration,
 }
 
 /// `CodePipelineConfiguration` represents a configuration for an Action Configuration
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineConfiguration {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -58,6 +58,7 @@ pub struct CodePipelineConfiguration {
 
 /// `CodePipelineInputArtifact` represents an input artifact
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineInputArtifact {
     pub location: CodePipelineInputLocation,
     pub revision: Option<String>,
@@ -68,8 +69,8 @@ pub struct CodePipelineInputArtifact {
 
 /// `CodePipelineInputLocation` represents a input location
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineInputLocation {
-    #[serde(rename = "s3Location")]
     pub s3_location: CodePipelineS3Location,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -79,19 +80,19 @@ pub struct CodePipelineInputLocation {
 
 /// `CodePipelineS3Location` represents an s3 input location
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineS3Location {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "bucketName")]
     pub bucket_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "objectKey")]
     pub object_key: Option<String>,
 }
 
 /// `CodePipelineOutputArtifact` represents an output artifact
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineOutputArtifact {
     pub location: CodePipelineInputLocation,
     pub revision: Option<String>,
@@ -102,8 +103,8 @@ pub struct CodePipelineOutputArtifact {
 
 /// `CodePipelineOutputLocation` represents a output location
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineOutputLocation {
-    #[serde(rename = "s3Location")]
     pub s3_location: CodePipelineS3Location,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -113,18 +114,16 @@ pub struct CodePipelineOutputLocation {
 
 /// `CodePipelineArtifactCredentials` represents CodePipeline artifact credentials
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodePipelineArtifactCredentials {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "secretAccessKey")]
     pub secret_access_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sessionToken")]
     pub session_token: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accessKeyId")]
     pub access_key_id: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/cognito.rs
+++ b/aws_lambda_events/src/generated/cognito.rs
@@ -6,26 +6,22 @@ use std::collections::HashMap;
 
 /// `CognitoEvent` contains data from an event sent from AWS Cognito Sync
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "datasetName")]
     pub dataset_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "datasetRecords")]
     pub dataset_records: HashMap<String, CognitoDatasetRecord>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventType")]
     pub event_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "identityId")]
     pub identity_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "identityPoolId")]
     pub identity_pool_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -35,14 +31,13 @@ pub struct CognitoEvent {
 
 /// `CognitoDatasetRecord` represents a record from an AWS Cognito Sync event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoDatasetRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "newValue")]
     pub new_value: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "oldValue")]
     pub old_value: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -52,6 +47,7 @@ pub struct CognitoDatasetRecord {
 /// `CognitoEventUserPoolsPreSignup` is sent by AWS Cognito User Pools when a user attempts to register
 /// (sign up), allowing a Lambda to perform custom validation to accept or deny the registration request
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreSignup {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -63,6 +59,7 @@ pub struct CognitoEventUserPoolsPreSignup {
 /// `CognitoEventUserPoolsPreAuthentication` is sent by AWS Cognito User Pools when a user submits their information
 /// to be authenticated, allowing you to perform custom validations to accept or deny the sign in request.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreAuthentication {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -74,6 +71,7 @@ pub struct CognitoEventUserPoolsPreAuthentication {
 /// `CognitoEventUserPoolsPostConfirmation` is sent by AWS Cognito User Pools after a user is confirmed,
 /// allowing the Lambda to send custom messages or add custom logic.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPostConfirmation {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -85,6 +83,7 @@ pub struct CognitoEventUserPoolsPostConfirmation {
 /// `CognitoEventUserPoolsPreTokenGen` is sent by AWS Cognito User Pools when a user attempts to retrieve
 /// credentials, allowing a Lambda to perform insert, suppress or override claims
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreTokenGen {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -96,6 +95,7 @@ pub struct CognitoEventUserPoolsPreTokenGen {
 /// `CognitoEventUserPoolsPostAuthentication` is sent by AWS Cognito User Pools after a user is authenticated,
 /// allowing the Lambda to add custom logic.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPostAuthentication {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -107,6 +107,7 @@ pub struct CognitoEventUserPoolsPostAuthentication {
 /// `CognitoEventUserPoolsMigrateUser` is sent by AWS Cognito User Pools when a user does not exist in the
 /// user pool at the time of sign-in with a password, or in the forgot-password flow.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsMigrateUser {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -121,6 +122,7 @@ pub struct CognitoEventUserPoolsMigrateUser {
 
 /// `CognitoEventUserPoolsCallerContext` contains information about the caller
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCallerContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -128,73 +130,64 @@ pub struct CognitoEventUserPoolsCallerContext {
     pub awssdk_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clientId")]
     pub client_id: Option<String>,
 }
 
 /// `CognitoEventUserPoolsHeader` contains common data from events sent by AWS Cognito User Pools
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsHeader {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "triggerSource")]
     pub trigger_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub region: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userPoolId")]
     pub user_pool_id: Option<String>,
-    #[serde(rename = "callerContext")]
     pub caller_context: CognitoEventUserPoolsCallerContext,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userName")]
     pub user_name: Option<String>,
 }
 
 /// `CognitoEventUserPoolsPreSignupRequest` contains the request portion of a PreSignup event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreSignupRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "validationData")]
     pub validation_data: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsPreSignupResponse` contains the response portion of a PreSignup event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreSignupResponse {
-    #[serde(rename = "autoConfirmUser")]
     pub auto_confirm_user: bool,
-    #[serde(rename = "autoVerifyEmail")]
     pub auto_verify_email: bool,
-    #[serde(rename = "autoVerifyPhone")]
     pub auto_verify_phone: bool,
 }
 
 /// `CognitoEventUserPoolsPreAuthenticationRequest` contains the request portion of a PreAuthentication event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreAuthenticationRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "validationData")]
     pub validation_data: HashMap<String, String>,
 }
 
@@ -204,14 +197,13 @@ pub struct CognitoEventUserPoolsPreAuthenticationResponse;
 
 /// `CognitoEventUserPoolsPostConfirmationRequest` contains the request portion of a PostConfirmation event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPostConfirmationRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
@@ -221,38 +213,34 @@ pub struct CognitoEventUserPoolsPostConfirmationResponse;
 
 /// `CognitoEventUserPoolsPreTokenGenRequest` contains request portion of PreTokenGen event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreTokenGenRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
-    #[serde(rename = "groupConfiguration")]
     pub group_configuration: GroupConfiguration,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsPreTokenGenResponse` containst the response portion of  a PreTokenGen event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreTokenGenResponse {
-    #[serde(rename = "claimsOverrideDetails")]
     pub claims_override_details: ClaimsOverrideDetails,
 }
 
 /// `CognitoEventUserPoolsPostAuthenticationRequest` contains the request portion of a PostAuthentication event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPostAuthenticationRequest {
-    #[serde(rename = "newDeviceUsed")]
     pub new_device_used: bool,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
@@ -262,112 +250,98 @@ pub struct CognitoEventUserPoolsPostAuthenticationResponse;
 
 /// `CognitoEventUserPoolsMigrateUserRequest` contains the request portion of a MigrateUser event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsMigrateUserRequest {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub password: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "validationData")]
     pub validation_data: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsMigrateUserResponse` contains the response portion of a MigrateUser event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsMigrateUserResponse {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "finalUserStatus")]
     pub final_user_status: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageAction")]
     pub message_action: Option<String>,
-    #[serde(rename = "desiredDeliveryMediums")]
     pub desired_delivery_mediums: Vec<String>,
-    #[serde(rename = "forceAliasCreation")]
     pub force_alias_creation: bool,
 }
 
 /// `ClaimsOverrideDetails` allows lambda to add, suppress or override claims in the token
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClaimsOverrideDetails {
-    #[serde(rename = "groupOverrideDetails")]
     pub group_override_details: GroupConfiguration,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "claimsToAddOrOverride")]
     pub claims_to_add_or_override: HashMap<String, String>,
-    #[serde(rename = "claimsToSuppress")]
     pub claims_to_suppress: Vec<String>,
 }
 
 /// `GroupConfiguration` allows lambda to override groups, roles and set a perferred role
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GroupConfiguration {
-    #[serde(rename = "groupsToOverride")]
     pub groups_to_override: Vec<String>,
-    #[serde(rename = "iamRolesToOverride")]
     pub iam_roles_to_override: Vec<String>,
-    #[serde(rename = "preferredRole")]
     pub preferred_role: Option<String>,
 }
 
 /// `CognitoEventUserPoolsChallengeResult` represents a challenge that is presented to the user in the authentication
 /// process that is underway, along with the corresponding result.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsChallengeResult {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "challengeName")]
     pub challenge_name: Option<String>,
-    #[serde(rename = "challengeResult")]
     pub challenge_result: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "challengeMetadata")]
     pub challenge_metadata: Option<String>,
 }
 
 /// `CognitoEventUserPoolsDefineAuthChallengeRequest` defines auth challenge request parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsDefineAuthChallengeRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     pub session: Vec<Option<CognitoEventUserPoolsChallengeResult>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
-    #[serde(rename = "userNotFound")]
     pub user_not_found: bool,
 }
 
 /// `CognitoEventUserPoolsDefineAuthChallengeResponse` defines auth challenge response parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsDefineAuthChallengeResponse {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "challengeName")]
     pub challenge_name: Option<String>,
-    #[serde(rename = "issueTokens")]
     pub issue_tokens: bool,
-    #[serde(rename = "failAuthentication")]
     pub fail_authentication: bool,
 }
 
 /// `CognitoEventUserPoolsDefineAuthChallenge` sent by AWS Cognito User Pools to initiate custom authentication flow
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsDefineAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -378,41 +352,38 @@ pub struct CognitoEventUserPoolsDefineAuthChallenge {
 
 /// `CognitoEventUserPoolsCreateAuthChallengeRequest` defines create auth challenge request parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCreateAuthChallengeRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "challengeName")]
     pub challenge_name: Option<String>,
     pub session: Vec<Option<CognitoEventUserPoolsChallengeResult>>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsCreateAuthChallengeResponse` defines create auth challenge response rarameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCreateAuthChallengeResponse {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "publicChallengeParameters")]
     pub public_challenge_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "privateChallengeParameters")]
     pub private_challenge_parameters: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "challengeMetadata")]
     pub challenge_metadata: Option<String>,
 }
 
 /// `CognitoEventUserPoolsCreateAuthChallenge` sent by AWS Cognito User Pools to create a challenge to present to the user
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCreateAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -423,6 +394,7 @@ pub struct CognitoEventUserPoolsCreateAuthChallenge {
 
 /// `CognitoEventUserPoolsVerifyAuthChallengeRequest` defines verify auth challenge request parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsVerifyAuthChallengeRequest<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -430,31 +402,28 @@ where
 {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "privateChallengeParameters")]
     pub private_challenge_parameters: HashMap<String, String>,
     #[serde(bound = "")]
-    #[serde(rename = "challengeAnswer")]
     pub challenge_answer: Option<T1>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsVerifyAuthChallengeResponse` defines verify auth challenge response parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsVerifyAuthChallengeResponse {
-    #[serde(rename = "answerCorrect")]
     pub answer_correct: bool,
 }
 
 /// `CognitoEventUserPoolsVerifyAuthChallenge` sent by AWS Cognito User Pools to verify if the response from the end user
 /// for a custom Auth Challenge is valid or not
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsVerifyAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -466,6 +435,7 @@ pub struct CognitoEventUserPoolsVerifyAuthChallenge {
 /// `CognitoEventUserPoolsCustomMessage` is sent by AWS Cognito User Pools before a verification or MFA message is sent,
 /// allowing a user to customize the message dynamically.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCustomMessage {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
@@ -476,6 +446,7 @@ pub struct CognitoEventUserPoolsCustomMessage {
 
 /// `CognitoEventUserPoolsCustomMessageRequest` contains the request portion of a CustomMessage event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCustomMessageRequest<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -484,36 +455,30 @@ where
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(bound = "")]
-    #[serde(rename = "userAttributes")]
     pub user_attributes: HashMap<String, T1>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "codeParameter")]
     pub code_parameter: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "usernameParameter")]
     pub username_parameter: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "clientMetadata")]
     pub client_metadata: HashMap<String, String>,
 }
 
 /// `CognitoEventUserPoolsCustomMessageResponse` contains the response portion of a CustomMessage event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCustomMessageResponse {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "smsMessage")]
     pub sms_message: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "emailMessage")]
     pub email_message: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "emailSubject")]
     pub email_subject: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/config.rs
+++ b/aws_lambda_events/src/generated/config.rs
@@ -2,51 +2,43 @@ use crate::custom_serde::*;
 
 /// `ConfigEvent` contains data from an event sent from AWS Config
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConfigEvent {
     /// The ID of the AWS account that owns the rule
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "accountId")]
     pub account_id: Option<String>,
     /// The ARN that AWS Config assigned to the rule
     ///
     /// nolint:stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "configRuleArn")]
     pub config_rule_arn: Option<String>,
     /// nolint:stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "configRuleId")]
     pub config_rule_id: Option<String>,
     /// The name that you assigned to the rule that caused AWS Config to publish the event
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "configRuleName")]
     pub config_rule_name: Option<String>,
     /// A boolean value that indicates whether the AWS resource to be evaluated has been removed from the rule's scope
-    #[serde(rename = "eventLeftScope")]
     pub event_left_scope: bool,
     /// nolint:stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "executionRoleArn")]
     pub execution_role_arn: Option<String>,
     /// If the event is published in response to a resource configuration change, this value contains a JSON configuration item
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invokingEvent")]
     pub invoking_event: Option<String>,
     /// A token that the function must pass to AWS Config with the PutEvaluations call
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resultToken")]
     pub result_token: Option<String>,
     /// Key/value pairs that the function processes as part of its evaluation logic
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "ruleParameters")]
     pub rule_parameters: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/connect.rs
+++ b/aws_lambda_events/src/generated/connect.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 /// `ConnectEvent` contains the data structure for a Connect event.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectEvent {
     #[serde(rename = "Details")]
     pub details: ConnectDetails,
@@ -15,6 +16,7 @@ pub struct ConnectEvent {
 
 /// `ConnectDetails` holds the details of a Connect event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectDetails {
     #[serde(rename = "ContactData")]
     pub contact_data: ConnectContactData,
@@ -27,6 +29,7 @@ pub struct ConnectDetails {
 
 /// `ConnectContactData` holds all of the contact information for the user that invoked the Connect event.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectContactData {
     /// The custom attributes from Connect that the Lambda function was invoked with.
     #[serde(deserialize_with = "deserialize_lambda_map")]
@@ -68,6 +71,7 @@ pub struct ConnectContactData {
 
 /// `ConnectEndpoint` represents routing information.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectEndpoint {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -81,6 +85,7 @@ pub struct ConnectEndpoint {
 
 /// `ConnectQueue` represents a queue object.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectQueue {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/ecr_scan.rs
+++ b/aws_lambda_events/src/generated/ecr_scan.rs
@@ -1,6 +1,7 @@
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EcrScanEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -29,6 +30,7 @@ pub struct EcrScanEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EcrScanEventDetailType {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -49,6 +51,7 @@ pub struct EcrScanEventDetailType {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EcrScanEventFindingSeverityCounts {
     #[serde(rename = "CRITICAL")]
     pub critical: i64,

--- a/aws_lambda_events/src/generated/firehose.rs
+++ b/aws_lambda_events/src/generated/firehose.rs
@@ -4,20 +4,18 @@ use std::collections::HashMap;
 
 /// `KinesisFirehoseEvent` represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationId")]
     pub invocation_id: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "deliveryStreamArn")]
     pub delivery_stream_arn: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sourceKinesisStreamArn")]
     pub source_kinesis_stream_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -26,12 +24,11 @@ pub struct KinesisFirehoseEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseEventRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "recordId")]
     pub record_id: Option<String>,
-    #[serde(rename = "approximateArrivalTimestamp")]
     pub approximate_arrival_timestamp: MillisecondTimestamp,
     pub data: Base64Data,
     #[serde(rename = "kinesisRecordMetadata")]
@@ -39,15 +36,16 @@ pub struct KinesisFirehoseEventRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseResponse {
     pub records: Vec<KinesisFirehoseResponseRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseResponseRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "recordId")]
     pub record_id: Option<String>,
     /// The status of the transformation. May be TransformedStateOk, TransformedStateDropped or TransformedStateProcessingFailed
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -58,30 +56,26 @@ pub struct KinesisFirehoseResponseRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseResponseRecordMetadata {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "partitionKeys")]
     pub partition_keys: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseRecordMetadata {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "shardId")]
     pub shard_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "partitionKey")]
     pub partition_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sequenceNumber")]
     pub sequence_number: Option<String>,
-    #[serde(rename = "subsequenceNumber")]
     pub subsequence_number: i64,
-    #[serde(rename = "approximateArrivalTimestamp")]
     pub approximate_arrival_timestamp: MillisecondTimestamp,
 }
 

--- a/aws_lambda_events/src/generated/iot.rs
+++ b/aws_lambda_events/src/generated/iot.rs
@@ -4,12 +4,10 @@ use http::HeaderMap;
 
 /// `IoTCustomAuthorizerRequest` contains data coming in to a custom IoT device gateway authorizer function.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTCustomAuthorizerRequest {
-    #[serde(rename = "httpContext")]
     pub http_context: Option<IoThttpContext>,
-    #[serde(rename = "mqttContext")]
     pub mqtt_context: Option<IoTmqttContext>,
-    #[serde(rename = "tlsContext")]
     pub tls_context: Option<IoTtlsContext>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -17,26 +15,25 @@ pub struct IoTCustomAuthorizerRequest {
     pub authorization_token: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "tokenSignature")]
     pub token_signature: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoThttpContext {
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "queryString")]
     pub query_string: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTmqttContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clientId")]
     pub client_id: Option<String>,
     pub password: Base64Data,
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -45,26 +42,22 @@ pub struct IoTmqttContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTtlsContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "serverName")]
     pub server_name: Option<String>,
 }
 
 /// `IoTCustomAuthorizerResponse` represents the expected format of an IoT device gateway authorization response.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTCustomAuthorizerResponse {
-    #[serde(rename = "isAuthenticated")]
     pub is_authenticated: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "principalId")]
     pub principal_id: Option<String>,
-    #[serde(rename = "disconnectAfterInSeconds")]
     pub disconnect_after_in_seconds: i32,
-    #[serde(rename = "refreshAfterInSeconds")]
     pub refresh_after_in_seconds: i32,
-    #[serde(rename = "policyDocuments")]
     pub policy_documents: Vec<String>,
 }

--- a/aws_lambda_events/src/generated/iot_1_click.rs
+++ b/aws_lambda_events/src/generated/iot_1_click.rs
@@ -4,59 +4,53 @@ use std::collections::HashMap;
 /// `IoTOneClickEvent` represents a click event published by clicking button type
 /// device.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTOneClickEvent {
-    #[serde(rename = "deviceEvent")]
     pub device_event: IoTOneClickDeviceEvent,
-    #[serde(rename = "deviceInfo")]
     pub device_info: IoTOneClickDeviceInfo,
-    #[serde(rename = "placementInfo")]
     pub placement_info: IoTOneClickPlacementInfo,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTOneClickDeviceEvent {
-    #[serde(rename = "buttonClicked")]
     pub button_clicked: IoTOneClickButtonClicked,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTOneClickButtonClicked {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clickType")]
     pub click_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "reportedTime")]
     pub reported_time: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTOneClickDeviceInfo {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "deviceId")]
     pub device_id: Option<String>,
-    #[serde(rename = "remainingLife")]
     pub remaining_life: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTOneClickPlacementInfo {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "projectName")]
     pub project_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "placementName")]
     pub placement_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/iot_button.rs
+++ b/aws_lambda_events/src/generated/iot_button.rs
@@ -1,18 +1,16 @@
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IoTButtonEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "serialNumber")]
     pub serial_number: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "clickType")]
     pub click_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "batteryVoltage")]
     pub battery_voltage: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/kafka.rs
+++ b/aws_lambda_events/src/generated/kafka.rs
@@ -3,25 +3,24 @@ use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KafkaEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSourceArn")]
     pub event_source_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub records: HashMap<String, Vec<KafkaRecord>>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "bootstrapServers")]
     pub bootstrap_servers: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KafkaRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -31,7 +30,6 @@ pub struct KafkaRecord {
     pub timestamp: MillisecondTimestamp,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "timestampType")]
     pub timestamp_type: Option<String>,
     pub key: Option<String>,
     pub value: Option<String>,

--- a/aws_lambda_events/src/generated/kinesis.rs
+++ b/aws_lambda_events/src/generated/kinesis.rs
@@ -2,17 +2,18 @@ use super::super::encodings::{Base64Data, SecondTimestamp};
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisEvent {
     #[serde(rename = "Records")]
     pub records: Vec<KinesisEventRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisEventRecord {
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "awsRegion")]
     pub aws_region: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -20,11 +21,9 @@ pub struct KinesisEventRecord {
     pub event_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventName")]
     pub event_name: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -33,34 +32,28 @@ pub struct KinesisEventRecord {
     pub event_source_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventVersion")]
     pub event_version: Option<String>,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invokeIdentityArn")]
     pub invoke_identity_arn: Option<String>,
     pub kinesis: KinesisRecord,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisRecord {
-    #[serde(rename = "approximateArrivalTimestamp")]
     pub approximate_arrival_timestamp: SecondTimestamp,
     pub data: Base64Data,
-    #[serde(rename = "encryptionType")]
     pub encryption_type: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "partitionKey")]
     pub partition_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "sequenceNumber")]
     pub sequence_number: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "kinesisSchemaVersion")]
     pub kinesis_schema_version: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/kinesis_analytics.rs
+++ b/aws_lambda_events/src/generated/kinesis_analytics.rs
@@ -2,37 +2,37 @@ use super::super::encodings::Base64Data;
 use crate::custom_serde::*;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisAnalyticsOutputDeliveryEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationId")]
     pub invocation_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "applicationArn")]
     pub application_arn: Option<String>,
     pub records: Vec<KinesisAnalyticsOutputDeliveryEventRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisAnalyticsOutputDeliveryEventRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "recordId")]
     pub record_id: Option<String>,
     pub data: Base64Data,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisAnalyticsOutputDeliveryResponse {
     pub records: Vec<KinesisAnalyticsOutputDeliveryResponseRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisAnalyticsOutputDeliveryResponseRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "recordId")]
     pub record_id: Option<String>,
     /// possible values include Ok and DeliveryFailed
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events/src/generated/lex.rs
+++ b/aws_lambda_events/src/generated/lex.rs
@@ -2,33 +2,25 @@ use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexEvent {
-    #[serde(rename = "messageVersion")]
     pub message_version: Option<String>,
-    #[serde(rename = "invocationSource")]
     pub invocation_source: Option<String>,
-    #[serde(rename = "userId")]
     pub user_id: Option<String>,
-    #[serde(rename = "inputTranscript")]
     pub input_transcript: Option<String>,
-    #[serde(rename = "sessionAttributes")]
     pub session_attributes: Option<SessionAttributes>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "requestAttributes")]
     pub request_attributes: HashMap<String, String>,
     pub bot: Option<LexBot>,
-    #[serde(rename = "outputDialogMode")]
     pub output_dialog_mode: Option<String>,
-    #[serde(rename = "currentIntent")]
     pub current_intent: Option<LexCurrentIntent>,
-    #[serde(rename = "alternativeIntents")]
     pub alternative_intents: Option<Vec<LexAlternativeIntents>>,
-    #[serde(rename = "dialogAction")]
     pub dialog_action: Option<LexDialogAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexBot {
     pub name: Option<String>,
     pub alias: Option<String>,
@@ -36,55 +28,47 @@ pub struct LexBot {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexCurrentIntent {
     pub name: Option<String>,
-    #[serde(rename = "nluIntentConfidenceScore")]
     pub nlu_intent_confidence_score: Option<f64>,
     pub slots: Option<Slots>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "slotDetails")]
     pub slot_details: HashMap<String, SlotDetail>,
-    #[serde(rename = "confirmationStatus")]
     pub confirmation_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexAlternativeIntents {
     pub name: Option<String>,
-    #[serde(rename = "nluIntentConfidenceScore")]
     pub nlu_intent_confidence_score: Option<f64>,
     pub slots: Option<Slots>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "slotDetails")]
     pub slot_details: HashMap<String, SlotDetail>,
-    #[serde(rename = "confirmationStatus")]
     pub confirmation_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SlotDetail {
     pub resolutions: Option<Vec<HashMap<String, String>>>,
-    #[serde(rename = "originalValue")]
     pub original_value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexDialogAction {
-    #[serde(rename = "type")]
     pub type_: Option<String>,
-    #[serde(rename = "fulfillmentState")]
     pub fulfillment_state: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub message: HashMap<String, String>,
-    #[serde(rename = "intentName")]
     pub intent_name: Option<String>,
     pub slots: Option<Slots>,
-    #[serde(rename = "slotToElicit")]
     pub slot_to_elicit: Option<String>,
-    #[serde(rename = "responseCard")]
     pub response_card: Option<LexResponseCard>,
 }
 
@@ -93,30 +77,26 @@ pub type SessionAttributes = HashMap<String, String>;
 pub type Slots = HashMap<String, Option<String>>;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexResponse {
-    #[serde(rename = "sessionAttributes")]
     pub session_attributes: SessionAttributes,
-    #[serde(rename = "dialogAction")]
     pub dialog_action: Option<LexDialogAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LexResponseCard {
     pub version: Option<i64>,
-    #[serde(rename = "contentType")]
     pub content_type: Option<String>,
-    #[serde(rename = "genericAttachments")]
     pub generic_attachments: Option<Vec<Attachment>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Attachment {
     pub title: Option<String>,
-    #[serde(rename = "subTitle")]
     pub sub_title: Option<String>,
-    #[serde(rename = "imageUrl")]
     pub image_url: Option<String>,
-    #[serde(rename = "attachmentLinkUrl")]
     pub attachment_link_url: Option<String>,
     pub buttons: Option<Vec<HashMap<String, String>>>,
 }

--- a/aws_lambda_events/src/generated/rabbitmq.rs
+++ b/aws_lambda_events/src/generated/rabbitmq.rs
@@ -5,14 +5,13 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RabbitMqEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSourceArn")]
     pub event_source_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -21,8 +20,8 @@ pub struct RabbitMqEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RabbitMqMessage {
-    #[serde(rename = "basicProperties")]
     pub basic_properties: RabbitMqBasicProperties,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -31,6 +30,7 @@ pub struct RabbitMqMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RabbitMqBasicProperties<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -38,41 +38,30 @@ where
 {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "contentType")]
     pub content_type: Option<String>,
-    #[serde(rename = "contentEncoding")]
     pub content_encoding: Option<String>,
     /// Application or header exchange table
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     #[serde(bound = "")]
     pub headers: HashMap<String, T1>,
-    #[serde(rename = "deliveryMode")]
     pub delivery_mode: u8,
     pub priority: u8,
-    #[serde(rename = "correlationId")]
     pub correlation_id: Option<String>,
-    #[serde(rename = "replyTo")]
     pub reply_to: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub expiration: Option<String>,
-    #[serde(rename = "messageId")]
     pub message_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub timestamp: Option<String>,
-    #[serde(rename = "type")]
     pub type_: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "userId")]
     pub user_id: Option<String>,
-    #[serde(rename = "appId")]
     pub app_id: Option<String>,
-    #[serde(rename = "clusterId")]
     pub cluster_id: Option<String>,
-    #[serde(rename = "bodySize")]
     pub body_size: u64,
 }
 

--- a/aws_lambda_events/src/generated/s3.rs
+++ b/aws_lambda_events/src/generated/s3.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 /// `S3Event` which wrap an array of `S3Event`Record
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3Event {
     #[serde(rename = "Records")]
     pub records: Vec<S3EventRecord>,
@@ -11,45 +12,40 @@ pub struct S3Event {
 
 /// `S3EventRecord` which wrap record data
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3EventRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventVersion")]
     pub event_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "awsRegion")]
     pub aws_region: Option<String>,
-    #[serde(rename = "eventTime")]
     pub event_time: DateTime<Utc>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventName")]
     pub event_name: Option<String>,
     #[serde(rename = "userIdentity")]
     pub principal_id: S3UserIdentity,
-    #[serde(rename = "requestParameters")]
     pub request_parameters: S3RequestParameters,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "responseElements")]
     pub response_elements: HashMap<String, String>,
     pub s3: S3Entity,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3UserIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "principalId")]
     pub principal_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3RequestParameters {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -58,6 +54,7 @@ pub struct S3RequestParameters {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3Entity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -65,18 +62,17 @@ pub struct S3Entity {
     pub schema_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "configurationId")]
     pub configuration_id: Option<String>,
     pub bucket: S3Bucket,
     pub object: S3Object,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3Bucket {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub name: Option<String>,
-    #[serde(rename = "ownerIdentity")]
     pub owner_identity: S3UserIdentity,
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -85,6 +81,7 @@ pub struct S3Bucket {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3Object {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -92,15 +89,12 @@ pub struct S3Object {
     pub size: Option<i64>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "urlDecodedKey")]
     pub url_decoded_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "versionId")]
     pub version_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eTag")]
     pub e_tag: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/s3_batch_job.rs
+++ b/aws_lambda_events/src/generated/s3_batch_job.rs
@@ -2,14 +2,13 @@ use crate::custom_serde::*;
 
 /// `S3BatchJobEvent` encapsulates the detail of a s3 batch job
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3BatchJobEvent {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationSchemaVersion")]
     pub invocation_schema_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationId")]
     pub invocation_id: Option<String>,
     pub job: S3BatchJob,
     pub tasks: Vec<S3BatchJobTask>,
@@ -17,6 +16,7 @@ pub struct S3BatchJobEvent {
 
 /// `S3BatchJob` whichs have the job id
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3BatchJob {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -25,56 +25,49 @@ pub struct S3BatchJob {
 
 /// `S3BatchJobTask` represents one task in the s3 batch job and have all task details
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3BatchJobTask {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "taskId")]
     pub task_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "s3Key")]
     pub s3_key: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "s3VersionId")]
     pub s3_version_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "s3BucketArn")]
     pub s3_bucket_arn: Option<String>,
 }
 
 /// `S3BatchJobResponse` is the response of a iven s3 batch job with the results
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3BatchJobResponse {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationSchemaVersion")]
     pub invocation_schema_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "treatMissingKeysAs")]
     pub treat_missing_keys_as: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "invocationId")]
     pub invocation_id: Option<String>,
     pub results: Vec<S3BatchJobResult>,
 }
 
 /// `S3BatchJobResult` represents the result of a given task
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct S3BatchJobResult {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "taskId")]
     pub task_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resultCode")]
     pub result_code: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "resultString")]
     pub result_string: Option<String>,
 }

--- a/aws_lambda_events/src/generated/ses.rs
+++ b/aws_lambda_events/src/generated/ses.rs
@@ -3,33 +3,34 @@ use chrono::{DateTime, Utc};
 
 /// `SimpleEmailEvent` is the outer structure of an event sent via SES.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailEvent {
     #[serde(rename = "Records")]
     pub records: Vec<SimpleEmailRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventVersion")]
     pub event_version: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     pub ses: SimpleEmailService,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailService {
     pub mail: SimpleEmailMessage,
     pub receipt: SimpleEmailReceipt,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailMessage {
-    #[serde(rename = "commonHeaders")]
     pub common_headers: SimpleEmailCommonHeaders,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -37,38 +38,31 @@ pub struct SimpleEmailMessage {
     pub timestamp: DateTime<Utc>,
     pub destination: Vec<String>,
     pub headers: Vec<SimpleEmailHeader>,
-    #[serde(rename = "headersTruncated")]
     pub headers_truncated: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageId")]
     pub message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailReceipt {
     pub recipients: Vec<String>,
     pub timestamp: DateTime<Utc>,
-    #[serde(rename = "spamVerdict")]
     pub spam_verdict: SimpleEmailVerdict,
-    #[serde(rename = "dkimVerdict")]
     pub dkim_verdict: SimpleEmailVerdict,
-    #[serde(rename = "dmarcVerdict")]
     pub dmarc_verdict: SimpleEmailVerdict,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "dmarcPolicy")]
     pub dmarc_policy: Option<String>,
-    #[serde(rename = "spfVerdict")]
     pub spf_verdict: SimpleEmailVerdict,
-    #[serde(rename = "virusVerdict")]
     pub virus_verdict: SimpleEmailVerdict,
     pub action: SimpleEmailReceiptAction,
-    #[serde(rename = "processingTimeMillis")]
     pub processing_time_millis: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailHeader {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -79,16 +73,15 @@ pub struct SimpleEmailHeader {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailCommonHeaders {
     pub from: Vec<String>,
     pub to: Vec<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "returnPath")]
     pub return_path: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageId")]
     pub message_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -103,32 +96,25 @@ pub struct SimpleEmailCommonHeaders {
 /// present for the Lambda Type, and the BucketName and ObjectKey fields are only
 /// present for the S3 Type.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailReceiptAction {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "type")]
     pub type_: Option<String>,
-    #[serde(rename = "topicArn")]
     pub topic_arn: Option<String>,
-    #[serde(rename = "bucketName")]
     pub bucket_name: Option<String>,
-    #[serde(rename = "objectKey")]
     pub object_key: Option<String>,
-    #[serde(rename = "smtpReplyCode")]
     pub smtp_reply_code: Option<String>,
-    #[serde(rename = "statusCode")]
     pub status_code: Option<String>,
     pub message: Option<String>,
     pub sender: Option<String>,
-    #[serde(rename = "invocationType")]
     pub invocation_type: Option<String>,
-    #[serde(rename = "functionArn")]
     pub function_arn: Option<String>,
-    #[serde(rename = "organizationArn")]
     pub organization_arn: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailVerdict {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -139,6 +125,7 @@ pub type SimpleEmailDispositionValue = String;
 
 /// `SimpleEmailDisposition` disposition return for SES to control rule functions
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailDisposition {
     pub disposition: SimpleEmailDispositionValue,
 }

--- a/aws_lambda_events/src/generated/sns.rs
+++ b/aws_lambda_events/src/generated/sns.rs
@@ -6,12 +6,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SnsEvent {
     #[serde(rename = "Records")]
     pub records: Vec<SnsEventRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SnsEventRecord {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -31,6 +33,7 @@ pub struct SnsEventRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SnsEntity<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -83,6 +86,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchAlarmSnsPayload {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -125,6 +129,7 @@ pub struct CloudWatchAlarmSnsPayload {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchAlarmTrigger {
     #[serde(rename = "Period")]
     pub period: i64,
@@ -161,6 +166,7 @@ pub struct CloudWatchAlarmTrigger {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchMetricDataQuery {
     #[serde(rename = "Expression")]
     pub expression: Option<String>,
@@ -180,6 +186,7 @@ pub struct CloudWatchMetricDataQuery {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchMetricStat {
     #[serde(rename = "Metric")]
     pub metric: CloudWatchMetric,
@@ -194,6 +201,7 @@ pub struct CloudWatchMetricStat {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchMetric {
     #[serde(rename = "Dimensions")]
     pub dimensions: Option<Vec<CloudWatchDimension>>,
@@ -204,6 +212,7 @@ pub struct CloudWatchMetric {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CloudWatchDimension {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]

--- a/aws_lambda_events/src/generated/sqs.rs
+++ b/aws_lambda_events/src/generated/sqs.rs
@@ -3,39 +3,36 @@ use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsEvent {
     #[serde(rename = "Records")]
     pub records: Vec<SqsMessage>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsMessage {
     /// nolint: stylecheck
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageId")]
     pub message_id: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "receiptHandle")]
     pub receipt_handle: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub body: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "md5OfBody")]
     pub md5_of_body: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "md5OfMessageAttributes")]
     pub md5_of_message_attributes: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub attributes: HashMap<String, String>,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
-    #[serde(rename = "messageAttributes")]
     pub message_attributes: HashMap<String, SqsMessageAttribute>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -43,27 +40,21 @@ pub struct SqsMessage {
     pub event_source_arn: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "eventSource")]
     pub event_source: Option<String>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "awsRegion")]
     pub aws_region: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsMessageAttribute {
-    #[serde(rename = "stringValue")]
     pub string_value: Option<String>,
-    #[serde(rename = "binaryValue")]
     pub binary_value: Option<Base64Data>,
-    #[serde(rename = "stringListValues")]
     pub string_list_values: Vec<String>,
-    #[serde(rename = "binaryListValues")]
     pub binary_list_values: Vec<Base64Data>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "dataType")]
     pub data_type: Option<String>,
 }
 

--- a/aws_lambda_events/src/generated/streams.rs
+++ b/aws_lambda_events/src/generated/streams.rs
@@ -2,48 +2,48 @@ use crate::custom_serde::*;
 
 /// `KinesisEventResponse` is the outer structure to report batch item failures for KinesisEvent.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisEventResponse {
-    #[serde(rename = "batchItemFailures")]
     pub batch_item_failures: Vec<KinesisBatchItemFailure>,
 }
 
 /// `KinesisBatchItemFailure` is the individual record which failed processing.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KinesisBatchItemFailure {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "itemIdentifier")]
     pub item_identifier: Option<String>,
 }
 
 /// `DynamoDbEventResponse` is the outer structure to report batch item failures for DynamoDBEvent.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DynamoDbEventResponse {
-    #[serde(rename = "batchItemFailures")]
     pub batch_item_failures: Vec<DynamoDbBatchItemFailure>,
 }
 
 /// `DynamoDbBatchItemFailure` is the individual record which failed processing.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DynamoDbBatchItemFailure {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "itemIdentifier")]
     pub item_identifier: Option<String>,
 }
 
 /// `SqsEventResponse` is the outer structure to report batch item failures for SQSEvent.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsEventResponse {
-    #[serde(rename = "batchItemFailures")]
     pub batch_item_failures: Vec<SqsBatchItemFailure>,
 }
 
 /// `SqsBatchItemFailure` is the individual record which failed processing.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsBatchItemFailure {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "itemIdentifier")]
     pub item_identifier: Option<String>,
 }

--- a/aws_lambda_events_codegen/Cargo.toml
+++ b/aws_lambda_events_codegen/Cargo.toml
@@ -10,5 +10,5 @@ quicli = "0.2"
 glob = "0.3"
 go_to_rust = { path = "./go_to_rust" }
 # Needed to pick up a bunch of changes.
-codegen = { git = "https://github.com/LegNeato/codegen.git", branch = "issue-3-and-4-field-documentation-annotation"}
+codegen = { git = "https://github.com/calavera/codegen.git", branch = "structure_attributes"}
 toml_edit = "0.13.0"

--- a/aws_lambda_events_codegen/go_to_rust/Cargo.toml
+++ b/aws_lambda_events_codegen/go_to_rust/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 pest = "^1.0"
 pest_derive = "^1.0"
 # Needed to pick up this PR: https://github.com/carllerche/codegen/pull/6
-codegen = { git = "https://github.com/LegNeato/codegen.git", branch = "issue-3-and-4-field-documentation-annotation"}
+codegen = { git = "https://github.com/calavera/codegen.git", branch = "structure_attributes"}
 failure = "0.1"
 heck = "0.3"
 regex = "^1.0"

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/array_of_array/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/array_of_array/expected.txt
@@ -1,7 +1,7 @@
 use super::super::encodings::Base64Data;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SqsMessageAttribute {
-    #[serde(rename = "binaryListValues")]
     pub binary_list_values: Vec<Base64Data>,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/field_doc_comment/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/field_doc_comment/expected.txt
@@ -2,6 +2,7 @@ use crate::custom_serde::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConnectDetails {
     #[serde(rename = "ContactData")]
     pub contact_data: ConnectContactData,
@@ -13,6 +14,7 @@ pub struct ConnectDetails {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
     /// Doc 1
     ///
@@ -22,6 +24,7 @@ pub struct Foo {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Bar {
     /// Doc a
     /// Doc b

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/float_sizes/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/float_sizes/expected.txt
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
     pub a: f64,
     pub b: f32,

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/int_sizes/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/int_sizes/expected.txt
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
     pub a: i64,
     pub b: i8,

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/multiple_definitions/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/multiple_definitions/expected.txt
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailEvent {
     pub blah: i64,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/omit_empty/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/omit_empty/expected.txt
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Foo {
     #[serde(rename = "blah")]
     pub bar: Option<i64>,

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/rename_reserved_keywords/expected.txt
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Fake {
     pub type_: u8,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_members/expected.txt
@@ -7,13 +7,13 @@ use std::collections::HashMap;
 use super::super::encodings::{Base64Data, MillisecondTimestamp, SecondTimestamp};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailMessage<T1=Value, T2=Value>
 where T1: DeserializeOwned,
       T1: Serialize,
       T2: DeserializeOwned,
       T2: Serialize,
 {
-    #[serde(rename = "commonHeaders")]
     pub common_headers: SimpleEmailCommonHeaders,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
@@ -24,11 +24,9 @@ where T1: DeserializeOwned,
     pub raw: Option<T1>,
     pub destination: Vec<String>,
     pub headers: Vec<SimpleEmailHeader>,
-    #[serde(rename = "headersTruncated")]
     pub headers_truncated: bool,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
-    #[serde(rename = "messageId")]
     pub message_id: Option<String>,
     pub resolutions: Vec<HashMap<String, String>>,
     pub blah: u64,

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_optional_interface_members/expected.txt
@@ -3,6 +3,7 @@ use serde::ser::Serialize;
 use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InterfaceMessage<T1=Value>
 where T1: DeserializeOwned,
       T1: Serialize,

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_comments/expected.txt
@@ -2,6 +2,7 @@ use crate::custom_serde::*;
 
 /// Foo
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SimpleEmailEvent {
     /// My cool thing
     #[serde(deserialize_with = "deserialize_lambda_string")]

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_default_contexts/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_default_contexts/expected.txt
@@ -2,14 +2,15 @@
 pub struct ApiGatewayRequestIdentity;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayProxyRequestContext {
     #[serde(default)]
     pub identity: ApiGatewayRequestIdentity,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HttpMessage {
     #[serde(default)]
-    #[serde(rename = "requestContext")]
     pub request_context: ApiGatewayProxyRequestContext,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_http_fields/expected.txt
@@ -3,33 +3,32 @@ use http::{HeaderMap, Method};
 use super::super::encodings::Body;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct HttpMessage {
     #[serde(with = "http_method")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Method,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
-    #[serde(rename = "multiValueHeaders")]
     pub multi_value_headers: HeaderMap,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "isBase64Encoded")]
     pub is_base64_encoded: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayProxyResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Body>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ApiGatewayWebsocketProxyRequest {
     #[serde(deserialize_with = "http_method::deserialize_optional")]
     #[serde(serialize_with = "http_method::serialize_optional")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "httpMethod")]
     pub http_method: Option<Method>,
 }

--- a/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/expected.txt
+++ b/aws_lambda_events_codegen/go_to_rust/tests/fixtures/struct_with_multiple_comments/expected.txt
@@ -1,6 +1,7 @@
 /// Foo
 /// Bar
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Whatever {
     pub blah: i64,
 }


### PR DESCRIPTION
Add `serde(rename_all = "camelCase")` to all structures,
and removes all rename attributes that are not necessary
because of this struct attribute. This should make the struct
definitions a little bit more compact and easier to read.

Notice that fields like `ref_` and `type_` don't need the rename attribute either because Serde will ignore the `_` character when it deserializes those fields: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e0b898d3749e919c5f5922d20ce0dbe6

Signed-off-by: David Calavera <david.calavera@gmail.com>
