### PR TITLE
fix: should not have a ts_nanosecond for approximate creation date time

### DIFF
--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -1,5 +1,5 @@
 use crate::custom_serde::*;
-use chrono::{serde::ts_nanoseconds, DateTime, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 
@@ -178,7 +178,6 @@ pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX
     /// epoch time (http://www.epochconverter.com/) format.
     #[serde(rename = "ApproximateCreationDateTime")]
-    #[serde(with = "ts_nanoseconds")]
     pub approximate_creation_date_time: DateTime<Utc>,
     /// The primary key attribute(s) for the DynamoDB item that was modified.
     #[serde(deserialize_with = "deserialize_lambda_map")]

--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -1,5 +1,5 @@
 use crate::custom_serde::*;
-use chrono::{DateTime, Utc};
+use chrono::{serde::ts_seconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 
@@ -178,6 +178,7 @@ pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX
     /// epoch time (http://www.epochconverter.com/) format.
     #[serde(rename = "ApproximateCreationDateTime")]
+    #[serde(with = "ts_seconds")]
     pub approximate_creation_date_time: DateTime<Utc>,
     /// The primary key attribute(s) for the DynamoDB item that was modified.
     #[serde(deserialize_with = "deserialize_lambda_map")]

--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -1,10 +1,106 @@
 use crate::custom_serde::*;
-use chrono::{serde::ts_seconds, DateTime, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt};
 
 pub mod attributes;
 use self::attributes::AttributeValue;
+
+pub mod ts_seconds_as_float {
+    use serde::{de, ser};
+    use std::fmt;
+
+    use chrono::offset::TimeZone;
+    use chrono::{DateTime, LocalResult, Utc};
+
+    enum SerdeError<V: fmt::Display, D: fmt::Display> {
+        NonExistent { timestamp: V },
+        Ambiguous { timestamp: V, min: D, max: D },
+    }
+
+    fn ne_timestamp<T: fmt::Display>(ts: T) -> SerdeError<T, u8> {
+        SerdeError::NonExistent::<T, u8> { timestamp: ts }
+    }
+
+    impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "ChronoSerdeError({})", self)
+        }
+    }
+
+    impl<V: fmt::Display, D: fmt::Display> fmt::Display for SerdeError<V, D> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                &SerdeError::NonExistent { ref timestamp } => {
+                    write!(f, "value is not a legal timestamp: {}", timestamp)
+                }
+                &SerdeError::Ambiguous {
+                    ref timestamp,
+                    ref min,
+                    ref max,
+                } => write!(
+                    f,
+                    "value is an ambiguous timestamp: {}, could be either of {}, {}",
+                    timestamp, min, max
+                ),
+            }
+        }
+    }
+
+    fn serde_from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
+    where
+        E: de::Error,
+        V: fmt::Display,
+        T: fmt::Display,
+    {
+        match me {
+            LocalResult::None => Err(E::custom(ne_timestamp(ts))),
+            LocalResult::Ambiguous(min, max) => Err(E::custom(SerdeError::Ambiguous {
+                timestamp: ts,
+                min,
+                max,
+            })),
+            LocalResult::Single(val) => Ok(val),
+        }
+    }
+
+    struct SecondsFloatTimestampVisitor;
+
+    /// Serialize a UTC datetime into an float number of seconds since the epoch
+    /// ```
+    pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        serializer.serialize_i64(dt.timestamp_millis() / 1000)
+    }
+
+    /// Deserialize a `DateTime` from a float seconds timestamp
+    pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        Ok(d.deserialize_f64(SecondsFloatTimestampVisitor)?)
+    }
+
+    impl<'de> de::Visitor<'de> for SecondsFloatTimestampVisitor {
+        type Value = DateTime<Utc>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a unix timestamp as a float")
+        }
+
+        /// Deserialize a timestamp in seconds since the epoch
+        fn visit_f64<E>(self, value: f64) -> Result<DateTime<Utc>, E>
+        where
+            E: de::Error,
+        {
+            let time_ms = (value.fract() * 1_000_000.).floor() as u32;
+            let time_s = value.trunc() as i64;
+            serde_from(Utc.timestamp_opt(time_s, time_ms), &value)
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -178,7 +274,7 @@ pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX
     /// epoch time (http://www.epochconverter.com/) format.
     #[serde(rename = "ApproximateCreationDateTime")]
-    #[serde(with = "ts_seconds")]
+    #[serde(with = "ts_seconds_as_float")]
     pub approximate_creation_date_time: DateTime<Utc>,
     /// The primary key attribute(s) for the DynamoDB item that was modified.
     #[serde(deserialize_with = "deserialize_lambda_map")]


### PR DESCRIPTION
There is an error supposing it's a nanosecond:
```
Error: Error("invalid type: floating point `1645532319`, expected a unix timestamp in nanoseconds", line: 1, column: 211)
```

And the format is really weird, it's a `seconds.ms` float.

![image](https://user-images.githubusercontent.com/1060101/155132764-af10c5e6-fc45-4e8e-bcef-2bf8938c2095.png)


Signed-off-by: Anthony Griffon <anthony@griffon.one>
