### PR TITLE
chore(cloudwatch): Add additional_event_data to CloudTrail

### DIFF
--- a/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
+++ b/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
@@ -16,6 +16,7 @@ pub struct AWSAPICall<I = Value, O = Value> {
     pub user_agent: String,
     pub request_parameters: I,
     pub response_elements: O,
+    pub additional_event_data: Value,
     #[serde(rename = "requestID")]
     pub request_id: String,
     #[serde(rename = "eventID")]

--- a/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
+++ b/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
@@ -16,7 +16,8 @@ pub struct AWSAPICall<I = Value, O = Value> {
     pub user_agent: String,
     pub request_parameters: I,
     pub response_elements: O,
-    pub additional_event_data: Value,
+    #[serde(default)]
+    pub additional_event_data: Option<Value>,
     #[serde(rename = "requestID")]
     pub request_id: String,
     #[serde(rename = "eventID")]


### PR DESCRIPTION
Almost forgot about this one 😅.

Reference: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html