### PR TITLE
Api gateway: Make client_cert optional

### DIFF
--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -478,6 +478,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source_ip: Option<String>,
+    #[serde(default)]
     pub client_cert: Option<ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert>,
 }
 
@@ -518,6 +519,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCertValidit
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthentication {
+    #[serde(default)]
     pub client_cert: Option<ApiGatewayV2httpRequestContextAuthenticationClientCert>,
 }
 

--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -478,7 +478,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub source_ip: Option<String>,
-    pub client_cert: ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert,
+    pub client_cert: Option<ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert>,
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCert` contains certificate information for the request caller if using mTLS.
@@ -518,7 +518,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentityClientCertValidit
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiGatewayV2httpRequestContextAuthentication {
-    pub client_cert: ApiGatewayV2httpRequestContextAuthenticationClientCert,
+    pub client_cert: Option<ApiGatewayV2httpRequestContextAuthenticationClientCert>,
 }
 
 /// `ApiGatewayV2httpRequestContextAuthenticationClientCert` contains client certificate information for the request caller if using mTLS.


### PR DESCRIPTION
The field is only set if using mTLS. See https://aws.amazon.com/blogs/compute/introducing-mutual-tls-authentication-for-amazon-api-gateway/

> For Lambda authorizers, the event payload is expanded to include additional certificate properties from the client’s authenticated certificate. These properties are found at requestContext.identity.clientCert with the Lambda authorizer v1 payload version or at requestContext.authentication.clientCert with the v2 payload version.