### PR TITLE
ApiGW: fix requestcontext.identity being optional

### DIFF
--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -469,7 +469,7 @@ where
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller including certificate information if using mTLS.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -588,7 +588,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(default)]
     pub request_id: Option<String>,
     #[serde(default)]
-    pub identity: ApiGatewayCustomAuthorizerRequestTypeRequestIdentity,
+    pub identity: Option<ApiGatewayCustomAuthorizerRequestTypeRequestIdentity>,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub resource_path: Option<String>,

--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -469,7 +469,7 @@ where
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller including certificate information if using mTLS.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiGatewayCustomAuthorizerRequestTypeRequestIdentity {
     #[serde(deserialize_with = "deserialize_lambda_string")]
@@ -587,6 +587,7 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequestContext {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub request_id: Option<String>,
+    #[serde(default)]
     pub identity: ApiGatewayCustomAuthorizerRequestTypeRequestIdentity,
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]


### PR DESCRIPTION
The identity field is not always given. At least this is the case if just `curl`ing an api gateway with a custom authorizer in Serverless Framework.

This matches https://github.com/LegNeato/aws-lambda-events/blob/9d44e2dab8aba85f33d13cdadc7439bbe1fae10b/aws_lambda_events/src/apigw/mod.rs#L419 and https://github.com/LegNeato/aws-lambda-events/blob/9d44e2dab8aba85f33d13cdadc7439bbe1fae10b/aws_lambda_events/src/apigw/mod.rs#L103