### PR TITLE
fix(dynamodb): Make `eventSource`, `eventVersion`, and `eventSourceARN` optional

### DIFF
--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -159,6 +159,12 @@ pub struct EventRecord {
     ///
     /// "dynamodb.amazonaws.com"
     pub user_identity: Option<UserIdentity>,
+    /// Describes the record format and relevant mapping information that
+    /// should be applied to schematize the records on the stream. For
+    /// DynamoDB Streams, this is application/json.
+    pub record_format: Option<String>,
+    /// The DynamoDB table that this event was recorded for.
+    pub table_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -137,17 +137,17 @@ pub struct EventRecord {
     pub event_name: String,
     /// The AWS service from which the stream record originated. For DynamoDB Streams,
     /// this is aws:dynamodb.
-    pub event_source: String,
+    pub event_source: Option<String>,
     /// The version number of the stream record format. This number is updated whenever
     /// the structure of Record is modified.
     ///
     /// Client applications must not assume that eventVersion will remain at a particular
     /// value, as this number is subject to change at any time. In general, eventVersion
     /// will only increase as the low-level DynamoDB Streams API evolves.
-    pub event_version: String,
+    pub event_version: Option<String>,
     /// The event source ARN of DynamoDB
     #[serde(rename = "eventSourceARN")]
-    pub event_source_arn: String,
+    pub event_source_arn: Option<String>,
     /// Items that are deleted by the Time to Live process after expiration have
     /// the following fields:
     ///


### PR DESCRIPTION
@calavera [as requested](https://github.com/LegNeato/aws-lambda-events/issues/84#issuecomment-1112629718), here's the PR!

Closes #84.