### PR TITLE
Fix issue deserializing url queries.

### DIFF
--- a/aws_lambda_events/Cargo.toml
+++ b/aws_lambda_events/Cargo.toml
@@ -26,7 +26,7 @@ serde_derive = "^1"
 serde_json = "^1"
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "^0.4.4", features = ["serde"] }
-query_map = { version = "^0.4", features = ["serde"] }
+query_map = { version = "^0.5", features = ["serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -31,9 +31,15 @@ where
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -141,7 +147,10 @@ pub struct ApiGatewayV2httpRequest {
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::serde::aws_api_gateway_v2::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::aws_api_gateway_v2::deserialize_empty"
+    )]
     pub query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -372,9 +381,15 @@ where
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -641,9 +656,15 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
+    #[serde(
+        default,
+        deserialize_with = "query_map::serde::standard::deserialize_empty"
+    )]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]

--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -31,9 +31,9 @@ where
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -141,7 +141,7 @@ pub struct ApiGatewayV2httpRequest {
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::aws_api_gateway_v2::deserialize_empty")]
     pub query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -372,9 +372,9 @@ where
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
@@ -641,9 +641,9 @@ pub struct ApiGatewayCustomAuthorizerRequestTypeRequest {
     #[serde(deserialize_with = "deserialize_headers", default)]
     #[serde(serialize_with = "serialize_multi_value_headers")]
     pub multi_value_headers: HeaderMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub query_string_parameters: QueryMap,
-    #[serde(default, deserialize_with = "query_map::deserialize_empty")]
+    #[serde(default, deserialize_with = "query_map::serde::standard::deserialize_empty")]
     pub multi_value_query_string_parameters: QueryMap,
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]


### PR DESCRIPTION
API GW V1 and V2 deserialize URL queries in different ways.
QueryMap includes two deserializers to fix this problem.

@adriandelgado this should fix the problem you bumped into.

Signed-off-by: David Calavera <david.calavera@gmail.com>