### PR TITLE
fix(aws_lambda_events): Mark session_context optional for CloudTrail

### DIFF
--- a/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
+++ b/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
@@ -32,7 +32,7 @@ pub struct UserIdentity {
     pub principal_id: String,
     pub arn: String,
     pub account_id: String,
-    pub session_context: SessionContext,
+    pub session_context: Option<SessionContext>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Session context is presumably only available if a role is assumed.