### PR TITLE
fix(aws_lambda_events): Mark response_elements optional 

### DIFF
--- a/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
+++ b/aws_lambda_events/src/cloudwatch_events/cloudtrail.rs
@@ -15,7 +15,7 @@ pub struct AWSAPICall<I = Value, O = Value> {
     pub source_ipaddress: String,
     pub user_agent: String,
     pub request_parameters: I,
-    pub response_elements: O,
+    pub response_elements: Option<O>,
     #[serde(default)]
     pub additional_event_data: Option<Value>,
     #[serde(rename = "requestID")]


### PR DESCRIPTION
`response_elements` is only set if the underlying API call is successful.