### PR TITLE
fix(sns): Properly handle non-required fields, and correct casing.

### DIFF
--- a/aws_lambda_events/src/generated/fixtures/example-sns-event.json
+++ b/aws_lambda_events/src/generated/fixtures/example-sns-event.json
@@ -5,26 +5,16 @@
       "EventSubscriptionArn": "arn:aws:sns:EXAMPLE", 
       "EventSource": "aws:sns", 
       "Sns": {
-        "Signature": "EXAMPLE", 
-        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e", 
-        "Type": "Notification", 
-        "TopicArn": "arn:aws:sns:EXAMPLE", 
-        "MessageAttributes": {
-          "Test": {
-            "Type": "String", 
-            "Value": "TestString"
-          }, 
-          "TestBinary": {
-            "Type": "Binary", 
-            "Value": "TestBinary"
-          }
-        }, 
-        "SignatureVersion": "1", 
-        "Timestamp": "2015-06-03T17:43:27.123Z", 
-        "SigningCertUrl": "EXAMPLE", 
-        "Message": "Hello from SNS!", 
-        "UnsubscribeUrl": "EXAMPLE", 
-        "Subject": "TestInvoke"
+        "Type" : "Notification",
+        "MessageId" : "82833b5c-8d5d-56d0-b0e1-7511f8253eb8",
+        "TopicArn" : "arn:aws:sns:us-east-1:246796806071:snsNetTest",
+        "Subject" : "Greetings",
+        "Message" : "Hello\r\nworld!",
+        "Timestamp" : "2015-08-18T18:02:32.111Z",
+        "SignatureVersion" : "1",
+        "Signature" : "e+khMfZriwAOTkF0OVm3tmdVq9eY6s5Bj6rXZty4B2TYssx7SSSBpvsDCiDuzgeHe++MNsGLDDT+5OpGEFBqCcd/K7iXhofz+KabMEtvM2Ku3aXcFixjOCAY1BF8hH6zU6nKzOy+m7K4UIoVqIOOhqsLWoXNFWgwQseBol1pFQ/MRi9UH84/WGdU8//dH+1/zjLxCud8Lg1vY9Yi/jxMU1HVpZ2JuvzJBdNBFJWc/VYAiw8K1r/J+dxAiLr87P96MgUqyg1wWxYe00HaEXGtjIctCNcd92s3pngOOeGvPYGaTIZEbYhSf2leMYd+CXujUHRqozru5K0Zp+l99fUNTg==",
+        "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem",
+        "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:246796806071:snsNetTest:228cc6c9-dcd8-4c92-9f3a-77f55176b9e3"
       }
     }
   ]

--- a/aws_lambda_events/src/sns/mod.rs
+++ b/aws_lambda_events/src/sns/mod.rs
@@ -49,6 +49,7 @@ pub struct SnsMessage {
     ///
     /// Preliminary tests show this appears in the lambda event JSON as `Subject: null`, marking as Option with need to test additional scenarios
     #[serde(deserialize_with = "deserialize_lambda_string")]
+    #[serde(default)]
     pub subject: Option<String>,
 
     /// The time (UTC) when the notification was published.
@@ -61,9 +62,11 @@ pub struct SnsMessage {
     pub signature: String,
 
     /// The URL to the certificate that was used to sign the message.
+    #[serde(rename = "SigningCertURL")]
     pub signing_cert_url: String,
 
     /// A URL that you can use to unsubscribe the endpoint from this topic. If you visit this URL, Amazon SNS unsubscribes the endpoint and stops sending notifications to this endpoint.
+    #[serde(rename = "UnsubscribeURL")]
     pub unsubscribe_url: String,
 
     /// The Message value specified when the notification was published to the topic.
@@ -71,6 +74,7 @@ pub struct SnsMessage {
 
     /// This is a HashMap of defined attributes for a message. Additional details can be found in the [SNS Developer Guide](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html)
     #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
     pub message_attributes: HashMap<String, MessageAttribute>,
 }
 


### PR DESCRIPTION
`Subject` and `MessageAttributes` may be completely missing from the payload.
Additionally `SigningCertURL` and `UnsubscribeURL` have fully capitalized `URL` unlike default renaming from serde of `Url`.

Examples for reference from the official .NET SDK.
https://github.com/aws/aws-sdk-net/blob/475822dec5e87954b7a47ac65995714ae1f1b115/sdk/test/Services/SimpleNotificationService/UnitTests/Custom/SNSMessageUtilityTests.cs#L26-L38
https://github.com/aws/aws-sdk-net/blob/449bb72eccfe78c2bfbd8ee2edbc2a7225e8323b/sdk/src/Services/SimpleNotificationService/Custom/Util/Message.cs#L73-L84