### PR TITLE
Fix nullable cognito pre-token-gen event ClaimsOverrideDetails

### DIFF
--- a/aws_lambda_events/src/cognito/mod.rs
+++ b/aws_lambda_events/src/cognito/mod.rs
@@ -620,6 +620,19 @@ mod test {
 
     #[test]
     #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_pretokengen_incoming() {
+        let data = include_bytes!(
+            "../generated/fixtures/example-cognito-event-userpools-pretokengen-incoming.json"
+        );
+        let parsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGen =
+            serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_pretokengen() {
         let data = include_bytes!(
             "../generated/fixtures/example-cognito-event-userpools-pretokengen.json"

--- a/aws_lambda_events/src/cognito/mod.rs
+++ b/aws_lambda_events/src/cognito/mod.rs
@@ -224,7 +224,7 @@ pub struct CognitoEventUserPoolsPreTokenGenRequest {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreTokenGenResponse {
-    pub claims_override_details: ClaimsOverrideDetails,
+    pub claims_override_details: Option<ClaimsOverrideDetails>,
 }
 
 /// `CognitoEventUserPoolsPostAuthenticationRequest` contains the request portion of a PostAuthentication event

--- a/aws_lambda_events/src/cognito/mod.rs
+++ b/aws_lambda_events/src/cognito/mod.rs
@@ -220,7 +220,7 @@ pub struct CognitoEventUserPoolsPreTokenGenRequest {
     pub client_metadata: HashMap<String, String>,
 }
 
-/// `CognitoEventUserPoolsPreTokenGenResponse` containst the response portion of  a PreTokenGen event
+/// `CognitoEventUserPoolsPreTokenGenResponse` contains the response portion of  a PreTokenGen event
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsPreTokenGenResponse {
@@ -286,7 +286,7 @@ pub struct ClaimsOverrideDetails {
     pub claims_to_suppress: Vec<String>,
 }
 
-/// `GroupConfiguration` allows lambda to override groups, roles and set a perferred role
+/// `GroupConfiguration` allows lambda to override groups, roles and set a preferred role
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupConfiguration {
@@ -363,7 +363,7 @@ pub struct CognitoEventUserPoolsCreateAuthChallengeRequest {
     pub client_metadata: HashMap<String, String>,
 }
 
-/// `CognitoEventUserPoolsCreateAuthChallengeResponse` defines create auth challenge response rarameters
+/// `CognitoEventUserPoolsCreateAuthChallengeResponse` defines create auth challenge response parameters
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsCreateAuthChallengeResponse {

--- a/aws_lambda_events/src/generated/fixtures/example-cognito-event-userpools-pretokengen-incoming.json
+++ b/aws_lambda_events/src/generated/fixtures/example-cognito-event-userpools-pretokengen-incoming.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "triggerSource": "PreTokenGen",
+  "region": "region",
+  "userPoolId": "userPoolId",
+  "userName": "userName",
+  "callerContext": {
+    "awsSdkVersion": "calling aws sdk with version",
+    "clientId": "apps client id"
+  },
+  "request": {
+    "userAttributes": {
+      "email": "email",
+      "phone_number": "phone_number"
+    },
+    "groupConfiguration": {
+      "groupsToOverride": ["group-A", "group-B", "group-C"],
+      "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
+      "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+    },
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    }
+  },
+  "response": {
+    "claimsOverrideDetails": null
+  }
+}
+


### PR DESCRIPTION
The actual incoming event for the Cognito pre-token-gen should have the claimsOverrideDetails field as optional.
This is what the incoming event looks like:

```json
{
  "version": "1",
  "triggerSource": "PreTokenGen",
  "region": "region",
  "userPoolId": "userPoolId",
  "userName": "userName",
  "callerContext": {
    "awsSdkVersion": "calling aws sdk with version",
    "clientId": "apps client id"
  },
  "request": {
    "userAttributes": {
      "email": "email",
      "phone_number": "phone_number"
    },
    "groupConfiguration": {
      "groupsToOverride": ["group-A", "group-B", "group-C"],
      "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
      "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
    },
    "clientMetadata": {
      "exampleMetadataKey": "example metadata value"
    }
  },
  "response": {
    "claimsOverrideDetails": null
  }
}
```
The events for cognito are not really well documented and differ from the actual events. 