### PR TITLE
Don't activate the time crate RUSTSEC-2020-0071

### DIFF
--- a/aws_lambda_events/Cargo.toml
+++ b/aws_lambda_events/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "^1"
 serde_with = { version = "^1", features = ["json"], optional = true }
 serde_json = "^1"
 bytes = { version = "1", features = ["serde"] }
-chrono = { version = "^0.4.4", features = ["serde"] }
+chrono = { version = "^0.4.4", default-features = false, features = ["serde", "std"] }
 query_map = { version = "^0.5", features = ["serde"] }
 flate2 = { version = "1.0.24", optional = true }
 


### PR DESCRIPTION
This PR solved:

```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.22
    └── aws_lambda_events 0.7.0
```