### PR TITLE
Restore S3Event

### DIFF
--- a/aws_lambda_events/src/s3/mod.rs
+++ b/aws_lambda_events/src/s3/mod.rs
@@ -1,5 +1,5 @@
 mod event;
-pub use event::*;
+pub use self::event::*;
 
 pub mod batch_job;
 pub mod object_lambda;


### PR DESCRIPTION
`aws_lambda_events::s3::S3Event` does not exist in 0.7.0. Restore it.

Fixes #113