### PR TITLE
Make SNS signature optional

### DIFF
--- a/aws_lambda_events/src/sns/mod.rs
+++ b/aws_lambda_events/src/sns/mod.rs
@@ -134,14 +134,14 @@ pub struct SnsMessageObj<T: Serialize> {
     pub timestamp: DateTime<Utc>,
 
     /// Version of the Amazon SNS signature used.
-    pub signature_version: String,
+    pub signature_version: Option<String>,
 
     /// Base64-encoded SHA1withRSA signature of the Message, MessageId, Subject (if present), Type, Timestamp, and TopicArn values.
-    pub signature: String,
+    pub signature: Option<String>,
 
     /// The URL to the certificate that was used to sign the message.
     #[serde(rename = "SigningCertURL")]
-    pub signing_cert_url: String,
+    pub signing_cert_url: Option<String>,
 
     /// A URL that you can use to unsubscribe the endpoint from this topic. If you visit this URL, Amazon SNS unsubscribes the endpoint and stops sending notifications to this endpoint.
     #[serde(rename = "UnsubscribeURL")]


### PR DESCRIPTION
In my SNS message (being posted on SQS) I dont have the signature fields:

```json
{
    "Records": [
        {
            "attributes": {
                "AWSTraceHeader": "Root=1-633375e5-6992f4381edc004f3f3beed3;Parent=7428100f69529302;Sampled=0",
                "ApproximateFirstReceiveTimestamp": "1664316902967",
                "ApproximateReceiveCount": "1",
                "MessageDeduplicationId": "9",
                "MessageGroupId": "Geert",
                "SenderId": "xxx",
                "SentTimestamp": "1664316902967",
                "SequenceNumber": "18872809200869103616"
            },
            "awsRegion": "eu-central-1",
            "body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"f5458878-95d1-5aad-82d9-d3d5edf775d9\",\n  \"SequenceNumber\" : \"10000000000000027000\",\n  \"TopicArn\" : \"arn:aws:sns:eu-central-1:xxx:dev-events.fifo\",\n  \"Message\" : \"{\\\"CustomerDepositedMoney\\\":{\\\"amount\\\":1000.0,\\\"balance\\\":9000.0}}\",\n  \"Timestamp\" : \"2022-09-27T22:15:02.834Z\",\n  \"UnsubscribeURL\" : \"https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:xxx:dev-events.fifo:aab561d9-73b3-4cdf-b527-9cbfa357eb47\"\n}",
            "eventSource": "aws:sqs",
            "eventSourceARN": "arn:aws:sqs:eu-central-1:xxx:dev-sqs1.fifo",
            "md5OfBody": "4fcc9a1791061d7fc91022734f84850f",
            "messageAttributes": {},
            "messageId": "bd9feb74-23c6-40b7-8b27-8af29b4c140a",
            "receiptHandle": "AQEB8m4uUDMmdKPi0AGmlyV30Eln411zJAi7GTQ0FZdkYOBzDlTwHUdEmXRBqWEa0Re3SwaOvhYx/4kj1DR5mLtJM7adYFj+ovAnUBHljr0gfaQe3WHY0l0vM9RVb/vqUI9weHH5fMCgqYXNanMjoA4KyplNewFvJo/KwxY3cF7LZIpaEZdFREJN5uU1h5u2tQKnCKvMValbToW6JU2LHuArXlo8y9VuS6mIHQVUCDYHn+QCze1JoEWC7EUuiPPaFbT2GjTmCuVr85DpYPH8WyDXvpoaujUWkWoj4rgtVp3AdCA="
        }
    ]
}
```

Which means my SNS message looks like:

```json
{
  "Type" : "Notification",
  "MessageId" : "f5458878-95d1-5aad-82d9-d3d5edf775d9",
  "SequenceNumber" : "10000000000000027000",
  "TopicArn" : "arn:aws:sns:eu-central-1:xxx:dev-events.fifo",
  "Message" : "{\"CustomerDepositedMoney\":{\"amount\":1000.0,\"balance\":9000.0}}",
  "Timestamp" : "2022-09-27T22:15:02.834Z",
  "UnsubscribeURL" : "https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:xxx:dev-events.fifo:aab561d9-73b3-4cdf-b527-9cbfa357eb47"
}
```

This PR makes them optional and confirmed to be working.