### PR TITLE
Add default serialization for cookies in Custom Authorizer v2 Request

### DIFF
--- a/aws_lambda_events/src/apigw/mod.rs
+++ b/aws_lambda_events/src/apigw/mod.rs
@@ -673,6 +673,7 @@ pub struct ApiGatewayV2CustomAuthorizerV2Request {
     #[serde(deserialize_with = "deserialize_lambda_string")]
     #[serde(default)]
     pub raw_query_string: Option<String>,
+    #[serde(default)]
     pub cookies: Vec<String>,
     #[serde(deserialize_with = "http_serde::header_map::deserialize", default)]
     #[serde(serialize_with = "serialize_headers")]
@@ -1052,9 +1053,23 @@ mod test {
         let data = include_bytes!(
             "../generated/fixtures/example-apigw-v2-custom-authorizer-v2-request.json"
         );
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request =
+            serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "apigw")]
+    fn example_apigw_v2_custom_authorizer_v2_request_without_cookies() {
+        let data = include_bytes!(
+            "../generated/fixtures/example-apigw-v2-custom-authorizer-v2-request-without-cookies.json"
+        );
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request =
+            serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/aws_lambda_events/src/generated/fixtures/example-apigw-v2-custom-authorizer-v2-request-without-cookies.json
+++ b/aws_lambda_events/src/generated/fixtures/example-apigw-v2-custom-authorizer-v2-request-without-cookies.json
@@ -1,0 +1,49 @@
+{
+  "version": "2.0",
+  "type": "REQUEST",
+  "routeArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request",
+  "identitySource": ["user1", "123"],
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "pathParameters": { "parameter1": "value1" },
+  "stageVariables": { "stageVariable1": "value1", "stageVariable2": "value2" }
+}


### PR DESCRIPTION
**Context**

When testing my CustomAuthorizer I got the `missing 'cookies' field` parsing error. It seems to be a required attribute without default setting, however it is not (always) provided by API Gateway.

**Changes**

- Added the serde `default` annotation to let Serde assume an empty cookie Vec in case the cookie attribute is not part of the request
- Added an example json without the cookie attribute
- Added a test for an example request json without the cookie attribute
- Fixed the test above that implied (the test function name) to be testing the same struct, but was actually using a different struct within the test

I hope this PR adds value, let me know if it raises any questions!