### PR TITLE
Use `serde_dynamo` for `dynamodb::Event` items

### DIFF
--- a/aws_lambda_events/Cargo.toml
+++ b/aws_lambda_events/Cargo.toml
@@ -23,6 +23,7 @@ serde = "^1"
 serde_derive = "^1"
 serde_with = { version = "^2", features = ["json"], optional = true }
 serde_json = "^1"
+serde_dynamo = { version = "^4.1", optional = true }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "^0.4.4", default-features = false, features = [
   "clock",
@@ -98,7 +99,7 @@ codepipeline_job = []
 cognito = []
 config = []
 connect = []
-dynamodb = ["streams"]
+dynamodb = ["streams", "serde_dynamo"]
 ecr_scan = []
 firehose = []
 iam = []

--- a/aws_lambda_events/src/dynamodb/attributes.rs
+++ b/aws_lambda_events/src/dynamodb/attributes.rs
@@ -1,145 +1,5 @@
-use serde::{
-    de::{Error as DeError, MapAccess, Visitor},
-    ser::SerializeMap,
-    Deserialize, Deserializer, Serialize, Serializer,
-};
-use std::{collections::HashMap, fmt};
-
-#[derive(Clone, Debug, Default, PartialEq)]
-pub enum AttributeValue {
-    #[default]
-    Null,
-    String(String),
-    Number(f64),
-    Boolean(bool),
-    Binary(Vec<u8>),
-    StringSet(Vec<String>),
-    NumberSet(Vec<f64>),
-    BinarySet(Vec<Vec<u8>>),
-    AttributeList(Vec<AttributeValue>),
-    AttributeMap(HashMap<String, AttributeValue>),
-}
-
-impl<'de> Deserialize<'de> for AttributeValue {
-    fn deserialize<D>(deserializer: D) -> Result<AttributeValue, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct AttributeValueVisitor;
-
-        impl<'de> Visitor<'de> for AttributeValueVisitor {
-            type Value = AttributeValue;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "a map")
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let key = match map.next_key::<String>()? {
-                    None => return Ok(AttributeValue::Null),
-                    Some(key) => key,
-                };
-
-                let value = match key.as_str() {
-                    "NULL" => {
-                        // consume the next value, even if we don't use it
-                        // Serde will fail because of trailing characters if we don't
-                        map.next_value::<bool>()?;
-                        AttributeValue::Null
-                    }
-                    "S" => AttributeValue::String(map.next_value::<String>()?),
-                    "N" => {
-                        let value = map.next_value::<String>()?;
-                        let value = value.parse::<f64>().map_err(|e| {
-                            A::Error::custom(format!("parse error {} for {}", e, &value))
-                        })?;
-                        AttributeValue::Number(value)
-                    }
-                    "B" => {
-                        let value = map.next_value::<String>()?;
-                        let value = base64::decode(&value).map_err(|e| {
-                            A::Error::custom(format!("parse error {} for {}", e, &value))
-                        })?;
-                        AttributeValue::Binary(value)
-                    }
-                    "BOOL" => AttributeValue::Boolean(map.next_value::<bool>()?),
-                    "SS" => AttributeValue::StringSet(map.next_value::<Vec<String>>()?),
-                    "NS" => {
-                        let value = map.next_value::<Vec<String>>()?;
-                        let set = value
-                            .into_iter()
-                            .flat_map(|s| {
-                                s.parse::<f64>().map_err(|e| {
-                                    A::Error::custom(format!("parse error {} for {}", e, &s))
-                                })
-                            })
-                            .collect::<Vec<_>>();
-                        AttributeValue::NumberSet(set)
-                    }
-                    "BS" => {
-                        let value = map.next_value::<Vec<String>>()?;
-                        let set = value
-                            .into_iter()
-                            .flat_map(|s| {
-                                base64::decode(&s).map_err(|e| {
-                                    A::Error::custom(format!("parse error {} for {}", e, &s))
-                                })
-                            })
-                            .collect::<Vec<_>>();
-                        AttributeValue::BinarySet(set)
-                    }
-                    "L" => AttributeValue::AttributeList(map.next_value::<Vec<AttributeValue>>()?),
-                    "M" => AttributeValue::AttributeMap(
-                        map.next_value::<HashMap<String, AttributeValue>>()?,
-                    ),
-                    other => {
-                        return Err(A::Error::custom(format!(
-                            "unexpected dynamodb type {}",
-                            other
-                        )))
-                    }
-                };
-                Ok(value)
-            }
-        }
-
-        deserializer.deserialize_map(AttributeValueVisitor)
-    }
-}
-
-impl Serialize for AttributeValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(1))?;
-        match self {
-            AttributeValue::Null => map.serialize_entry("NULL", &true)?,
-            AttributeValue::String(s) => map.serialize_entry("S", s)?,
-            AttributeValue::Number(n) => map.serialize_entry("N", &n.to_string())?,
-            AttributeValue::Boolean(b) => map.serialize_entry("BOOL", b)?,
-            AttributeValue::Binary(b) => {
-                let value = base64::encode(b);
-                map.serialize_entry("B", &value)?
-            }
-            AttributeValue::StringSet(s) => map.serialize_entry("SS", s)?,
-            AttributeValue::NumberSet(s) => {
-                let value = s.iter().map(|n| n.to_string()).collect::<Vec<_>>();
-                map.serialize_entry("NS", &value)?
-            }
-            AttributeValue::BinarySet(s) => {
-                let value = s.iter().map(base64::encode).collect::<Vec<_>>();
-                map.serialize_entry("BS", &value)?
-            }
-            AttributeValue::AttributeList(l) => map.serialize_entry("L", l)?,
-            AttributeValue::AttributeMap(m) => map.serialize_entry("M", m)?,
-        }
-        map.end()
-    }
-}
+use serde_dynamo::AttributeValue;
+use std::collections::HashMap;
 
 #[cfg(test)]
 mod test {
@@ -153,7 +13,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::Null => {}
+            AttributeValue::Null(true) => {}
             other => panic!("unexpected value {:?}", other),
         }
 
@@ -169,7 +29,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::String(ref s) => assert_eq!("value", s.as_str()),
+            AttributeValue::S(ref s) => assert_eq!("value", s.as_str()),
             other => panic!("unexpected value {:?}", other),
         }
 
@@ -185,7 +45,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::Number(n) => assert_eq!(123.45, n),
+            AttributeValue::N(ref n) => assert_eq!("123.45", n.as_str()),
             other => panic!("unexpected value {:?}", other),
         }
 
@@ -201,7 +61,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::Binary(ref b) => {
+            AttributeValue::B(ref b) => {
                 let expected = base64::decode("dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk").unwrap();
                 assert_eq!(&expected, b)
             }
@@ -220,7 +80,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::Boolean(b) => assert_eq!(true, b),
+            AttributeValue::Bool(b) => assert_eq!(true, b),
             other => panic!("unexpected value {:?}", other),
         }
 
@@ -236,7 +96,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::StringSet(ref s) => {
+            AttributeValue::Ss(ref s) => {
                 let expected = vec!["Giraffe", "Hippo", "Zebra"];
                 assert_eq!(expected, s.iter().collect::<Vec<_>>());
             }
@@ -255,9 +115,9 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::NumberSet(ref s) => {
-                let expected = vec![42.2, -19.00, 7.5, 3.14];
-                assert_eq!(&expected, s);
+            AttributeValue::Ns(ref s) => {
+                let expected = vec!["42.2", "-19", "7.5", "3.14"];
+                assert_eq!(expected, s.iter().collect::<Vec<_>>());
             }
             other => panic!("unexpected value {:?}", other),
         }
@@ -274,7 +134,7 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::BinarySet(ref s) => {
+            AttributeValue::Bs(ref s) => {
                 let expected = vec!["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
                     .into_iter()
                     .flat_map(|s| base64::decode(&s))
@@ -296,11 +156,11 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
         match attr {
-            AttributeValue::AttributeList(ref s) => {
+            AttributeValue::L(ref s) => {
                 let expected = vec![
-                    AttributeValue::String("Cookies".into()),
-                    AttributeValue::String("Coffee".into()),
-                    AttributeValue::Number(3.14159),
+                    AttributeValue::S("Cookies".into()),
+                    AttributeValue::S("Coffee".into()),
+                    AttributeValue::N("3.14159".into()),
                 ];
                 assert_eq!(&expected, s);
             }
@@ -319,10 +179,10 @@ mod test {
 
         let attr: AttributeValue = serde_json::from_value(value).unwrap();
         match attr {
-            AttributeValue::AttributeMap(s) => {
+            AttributeValue::M(s) => {
                 let mut expected = HashMap::new();
-                expected.insert("Name".into(), AttributeValue::String("Joe".into()));
-                expected.insert("Age".into(), AttributeValue::Number(35.00));
+                expected.insert("Name".into(), AttributeValue::S("Joe".into()));
+                expected.insert("Age".into(), AttributeValue::N("35".into()));
                 assert_eq!(expected, s);
             }
             other => panic!("unexpected value {:?}", other),

--- a/aws_lambda_events/src/dynamodb/mod.rs
+++ b/aws_lambda_events/src/dynamodb/mod.rs
@@ -3,10 +3,10 @@ use crate::streams::DynamoDbBatchItemFailure;
 use crate::time_window::*;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt};
+use std::fmt;
 
-pub mod attributes;
-use self::attributes::AttributeValue;
+#[cfg(test)]
+mod attributes;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -218,20 +218,20 @@ pub struct StreamRecord {
     #[serde(with = "float_unix_epoch")]
     pub approximate_creation_date_time: DateTime<Utc>,
     /// The primary key attribute(s) for the DynamoDB item that was modified.
-    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(deserialize_with = "deserialize_lambda_dynamodb_item")]
     #[serde(default)]
     #[serde(rename = "Keys")]
-    pub keys: HashMap<String, AttributeValue>,
+    pub keys: serde_dynamo::Item,
     /// The item in the DynamoDB table as it appeared after it was modified.
-    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(deserialize_with = "deserialize_lambda_dynamodb_item")]
     #[serde(default)]
     #[serde(rename = "NewImage")]
-    pub new_image: HashMap<String, AttributeValue>,
+    pub new_image: serde_dynamo::Item,
     /// The item in the DynamoDB table as it appeared before it was modified.
-    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(deserialize_with = "deserialize_lambda_dynamodb_item")]
     #[serde(default)]
     #[serde(rename = "OldImage")]
-    pub old_image: HashMap<String, AttributeValue>,
+    pub old_image: serde_dynamo::Item,
     /// The sequence number of the stream record.
     #[serde(default)]
     #[serde(rename = "SequenceNumber")]

--- a/aws_lambda_events/src/lib.rs
+++ b/aws_lambda_events/src/lib.rs
@@ -88,6 +88,8 @@ pub mod connect;
 
 /// AWS Lambda event definitions for dynamodb.
 #[cfg(feature = "dynamodb")]
+extern crate serde_dynamo;
+#[cfg(feature = "dynamodb")]
 pub mod dynamodb;
 
 /// AWS Lambda event definitions for ecr_scan.


### PR DESCRIPTION
Use [`serde_dynamo::Item`](https://docs.rs/serde_dynamo/latest/serde_dynamo/struct.Item.html) instead of `HashMap<String, AttributeValue>` to represent the `keys`, `old_image`, and `new_image` in a `dynamodb::Event`.

This consolidates the Rust/DynamoDB ecosystem around fewer representations of DynamoDB items.

Note that [`serde_dynamo::AttributeValue`](https://docs.rs/serde_dynamo/latest/serde_dynamo/enum.AttributeValue.html) and
[`aws_lambda_events::dynamodb::attributes::AttributeValue`](https://docs.rs/aws_lambda_events/latest/aws_lambda_events/dynamodb/attributes/enum.AttributeValue.html) are slightly different (especially with regards to the `Number` enumeration) so this is a breaking change that would either need to go behind a feature flag or a major version bump.

---

I feel like this might be of interest to the wider community because
* I see lots of instances in GitHub search of `dynamodb::Event` and `serde_dynamo` used together already, and
* Like using `serde_json`, this helps prompt users to convert to a typed representation of their entity earlier.

I'm curious whether you think this is useful for aws-lambda-events and the wider Rust+AWS ecosystem.