### PR TITLE
Mark kinesisRecordMetadata optional

### DIFF
--- a/aws_lambda_events/src/firehose/mod.rs
+++ b/aws_lambda_events/src/firehose/mod.rs
@@ -27,7 +27,7 @@ pub struct KinesisFirehoseEventRecord {
     pub approximate_arrival_timestamp: MillisecondTimestamp,
     pub data: Base64Data,
     #[serde(rename = "kinesisRecordMetadata")]
-    pub kinesis_firehose_record_metadata: KinesisFirehoseRecordMetadata,
+    pub kinesis_firehose_record_metadata: Option<KinesisFirehoseRecordMetadata>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
`kinesisRecordMetadata` is only populated if the Firehose source is a Kinesis stream.