### PR TITLE
Change SNS url "rename" to "alias" to support both *URL and *Url

### DIFF
--- a/src/fixtures/example-sns-event-pascal-case.json
+++ b/src/fixtures/example-sns-event-pascal-case.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:EXAMPLE",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "Type" : "Notification",
+        "MessageId" : "82833b5c-8d5d-56d0-b0e1-7511f8253eb8",
+        "TopicArn" : "arn:aws:sns:us-east-1:246796806071:snsNetTest",
+        "Subject" : "Greetings",
+        "Message" : "Hello\r\nworld!",
+        "Timestamp" : "2015-08-18T18:02:32.111Z",
+        "SignatureVersion" : "1",
+        "Signature" : "e+khMfZriwAOTkF0OVm3tmdVq9eY6s5Bj6rXZty4B2TYssx7SSSBpvsDCiDuzgeHe++MNsGLDDT+5OpGEFBqCcd/K7iXhofz+KabMEtvM2Ku3aXcFixjOCAY1BF8hH6zU6nKzOy+m7K4UIoVqIOOhqsLWoXNFWgwQseBol1pFQ/MRi9UH84/WGdU8//dH+1/zjLxCud8Lg1vY9Yi/jxMU1HVpZ2JuvzJBdNBFJWc/VYAiw8K1r/J+dxAiLr87P96MgUqyg1wWxYe00HaEXGtjIctCNcd92s3pngOOeGvPYGaTIZEbYhSf2leMYd+CXujUHRqozru5K0Zp+l99fUNTg==",
+        "SigningCertUrl" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-d6d679a1d18e95c2f9ffcf11f4f9e198.pem",
+        "UnsubscribeUrl" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:246796806071:snsNetTest:228cc6c9-dcd8-4c92-9f3a-77f55176b9e3"
+      }
+    }
+  ]
+}
+

--- a/src/sns/mod.rs
+++ b/src/sns/mod.rs
@@ -62,11 +62,11 @@ pub struct SnsMessage {
     pub signature: String,
 
     /// The URL to the certificate that was used to sign the message.
-    #[serde(rename = "SigningCertURL")]
+    #[serde(alias = "SigningCertURL")]
     pub signing_cert_url: String,
 
     /// A URL that you can use to unsubscribe the endpoint from this topic. If you visit this URL, Amazon SNS unsubscribes the endpoint and stops sending notifications to this endpoint.
-    #[serde(rename = "UnsubscribeURL")]
+    #[serde(alias = "UnsubscribeURL")]
     pub unsubscribe_url: String,
 
     /// The Message value specified when the notification was published to the topic.
@@ -140,11 +140,11 @@ pub struct SnsMessageObj<T: Serialize> {
     pub signature: String,
 
     /// The URL to the certificate that was used to sign the message.
-    #[serde(rename = "SigningCertURL")]
+    #[serde(alias = "SigningCertURL")]
     pub signing_cert_url: String,
 
     /// A URL that you can use to unsubscribe the endpoint from this topic. If you visit this URL, Amazon SNS unsubscribes the endpoint and stops sending notifications to this endpoint.
-    #[serde(rename = "UnsubscribeURL")]
+    #[serde(alias = "UnsubscribeURL")]
     pub unsubscribe_url: String,
 
     /// Deserialized into a `T` from nested JSON inside the SNS message string. `T` must implement the `Deserialize` or `DeserializeOwned` trait.
@@ -184,6 +184,16 @@ mod test {
     #[cfg(feature = "sns")]
     fn my_example_sns_event() {
         let data = include_bytes!("../fixtures/example-sns-event.json");
+        let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "sns")]
+    fn my_example_sns_event_pascal_case() {
+        let data = include_bytes!("../fixtures/example-sns-event-pascal-case.json");
         let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();


### PR DESCRIPTION
We found conflicting docs on AWS that show usage of `*URL` as well as `*Url`. To support both, the `rename` change I made in the last commit has been changed to an `alias`. So this will now default to `Url`, but also deserialize from `URL` with this change. I've also added a test to validate this works as expected.

Thanks to @yotamofek for bringing this up in https://github.com/calavera/aws-lambda-events/pull/141#issuecomment-1484148166
