### PR TITLE
Include `content` field of `SimpleEmailService` struct - Fixes #148

### DIFF
--- a/src/ses/mod.rs
+++ b/src/ses/mod.rs
@@ -23,6 +23,7 @@ pub struct SimpleEmailRecord {
 pub struct SimpleEmailService {
     pub mail: SimpleEmailMessage,
     pub receipt: SimpleEmailReceipt,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
The SimpleEmailService struct contains only the fields mail and receipt (https://github.com/calavera/aws-lambda-events/blob/main/src/ses/mod.rs#L23-L26), however the AWS docs (https://docs.aws.amazon.com/ses/latest/dg/receiving-email-notifications-contents.html) say that there are two more fields that can be present, notificationType and content.

This pull request includes the content field - I decided not to include the notificationType field as from what I can tell this never provides any meaningful data, and may create problems with test cases as the current ones do not include the field and, while the spec says it should be present, it is also not present in some of the examples in the AWS documentation which would be confusing.