### PR TITLE
Bugfix/stringlistvalue

### DIFF
--- a/src/sqs/mod.rs
+++ b/src/sqs/mod.rs
@@ -91,8 +91,10 @@ pub struct SqsMessageObj<T: Serialize> {
 pub struct SqsMessageAttribute {
     pub string_value: Option<String>,
     pub binary_value: Option<Base64Data>,
-    pub string_list_values: Vec<String> = Vec::new(),
-    pub binary_list_values: Vec<Base64Data> = Vec::new(),
+    #[serde(default)]
+    pub string_list_values: Vec<String>,
+    #[serde(default)]
+    pub binary_list_values: Vec<Base64Data>,
     #[serde(default)]
     pub data_type: Option<String>,
 }

--- a/src/sqs/mod.rs
+++ b/src/sqs/mod.rs
@@ -91,8 +91,8 @@ pub struct SqsMessageObj<T: Serialize> {
 pub struct SqsMessageAttribute {
     pub string_value: Option<String>,
     pub binary_value: Option<Base64Data>,
-    pub string_list_values: Vec<String>,
-    pub binary_list_values: Vec<Base64Data>,
+    pub string_list_values: Vec<String> = Vec::new(),
+    pub binary_list_values: Vec<Base64Data> = Vec::new(),
     #[serde(default)]
     pub data_type: Option<String>,
 }


### PR DESCRIPTION
Probably related: https://github.com/calavera/aws-lambda-events/issues/81

The `string_list_values` and `binary_list_values` are not required in the `MessageAttributes` object of the SQS payload. [Doc](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html).

We encountered a bug where the lambda throws an error with a message attributes like this:

```

{
    "action": {
        "DataType": "String",
        "StringValue": "CREATE"
    }
}

```

CHANGES
- Add `#[serde(default)]` for non-required vectors.